### PR TITLE
feat(grammar): support more preprocessor directives

### DIFF
--- a/examples/Xresources
+++ b/examples/Xresources
@@ -3,6 +3,13 @@
 #define USERNAME bones
 #undef USERNAME
 
+#define empty() One /* hello */
+#define hello1()  Hello
+#define hello2(one)
+#define hello3(one, two) ((one) + (two))
+#define hello4(X, ...)  Hello __VA_ARGS__, I am X
+#define hello5(...) Hello __VA_ARGS__
+
 ! native comment
 
 // C style comments

--- a/examples/Xresources
+++ b/examples/Xresources
@@ -10,6 +10,9 @@
 #define hello4(X, ...)  Hello __VA_ARGS__, I am X
 #define hello5(...) Hello __VA_ARGS__
 
+#hello world
+#warning "Hello"
+
 ! native comment
 
 // C style comments

--- a/examples/Xresources
+++ b/examples/Xresources
@@ -1,5 +1,8 @@
 #include "./foo/bar"
 
+#define USERNAME bones
+#undef USERNAME
+
 ! native comment
 
 // C style comments

--- a/grammar.js
+++ b/grammar.js
@@ -88,8 +88,15 @@ export default grammar({
       field('condition', $.identifier),
       NEWLINE,
       field('consequence', alias(repeat($._line), $.body)),
+      repeat(field('alternative', $.elifdef_directive)),
       optional(field('alternative', $.else_directive)),
       directive('endif'),
+    ),
+
+    elifdef_directive: $ => seq(
+      choice(directive('elifdef'), directive('elifndef')),
+      field('condition', $.identifier),
+      repeat($._line),
     ),
 
     else_directive: $ => seq(directive('else'), NEWLINE, repeat($._line)),

--- a/grammar.js
+++ b/grammar.js
@@ -4,6 +4,7 @@
 const ANY_CHAR = /[^\x00\n]/;
 const WHITE_SPACE = /[ \t]/;
 const NEWLINE = /\n/;
+const C_IDENTIFIER = /[a-zA-Z_]\w*/;
 
 export default grammar({
   name: 'xresources',
@@ -23,6 +24,7 @@ export default grammar({
       $.ifdef_directive,
       $.include_directive,
       $.resource,
+      $.simple_directive,
       $.undef_directive,
     ),
 
@@ -119,7 +121,14 @@ export default grammar({
 
     else_directive: $ => seq(directive('else'), NEWLINE, repeat($._line)),
 
-    identifier: _ => /[a-zA-Z_][a-zA-Z0-9_]*/,
+    simple_directive: $ => seq(
+      field('name', $.directive),
+      field('value', optional($.expansion)),
+    ),
+
+    directive: _ => token(seq('#', repeat(WHITE_SPACE), C_IDENTIFIER)),
+
+    identifier: _ => C_IDENTIFIER,
   },
 });
 

--- a/grammar.js
+++ b/grammar.js
@@ -19,6 +19,7 @@ export default grammar({
       $.comment,
       $.define_directive,
       $.define_function_directive,
+      $.if_directive,
       $.ifdef_directive,
       $.include_directive,
       $.resource,
@@ -83,14 +84,31 @@ export default grammar({
 
     undef_directive: $ => seq(directive('undef'), field('name', $.identifier)),
 
+    if_directive: $ => seq(
+      directive('if'),
+      field('condition', $.expansion),
+      NEWLINE,
+      $._if_directive_body,
+    ),
+
     ifdef_directive: $ => seq(
       choice(directive('ifdef'), directive('ifndef')),
       field('condition', $.identifier),
       NEWLINE,
+      $._if_directive_body,
+    ),
+
+    _if_directive_body: $ => seq(
       field('consequence', alias(repeat($._line), $.body)),
-      repeat(field('alternative', $.elifdef_directive)),
+      repeat(field('alternative', choice($.elif_directive, $.elifdef_directive))),
       optional(field('alternative', $.else_directive)),
       directive('endif'),
+    ),
+
+    elif_directive: $ => seq(
+      directive('elif'),
+      field('condition', $.expansion),
+      repeat($._line),
     ),
 
     elifdef_directive: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -32,29 +32,6 @@ export default grammar({
       seq('/*', /[^*]*\*+([^/*][^*]*\*+)*/, '/'),
     )),
 
-    include_directive: $ => seq(directive('include'), field('file', $.string)),
-
-    define_directive: $ => seq(
-      directive('define'),
-      field('name', $.identifier),
-      repeat(WHITE_SPACE),
-      optional(field('value', $.expansion))
-    ),
-    expansion: _ => seq(/\S/, repeat(choice(/./, /\\\n/))),
-
-    ifdef_directive: $ => seq(
-      choice(directive('ifdef'), directive('ifndef')),
-      field('condition', $.identifier),
-      NEWLINE,
-      field('consequence', alias(repeat($._line), $.body)),
-      optional(field('alternative', $.else_directive)),
-      directive('endif'),
-    ),
-
-    else_directive: $ => seq(directive('else'), NEWLINE, repeat($._line)),
-
-    identifier: _ => /[a-zA-Z_][a-zA-Z0-9_]+/,
-
     resource: $ => seq(
       field('name', $.components),
       ':',
@@ -77,6 +54,30 @@ export default grammar({
     escape_sequence: _ => token(seq('\\', choice('n', '\\', '\t', '\n', ' ', /[0-7]{3}/))),
     resource_value: $ => repeat1(choice(ANY_CHAR, $.escape_sequence)),
     string: $ => seq('"', alias(/[^\n"]*/, $.string_content), '"'),
+
+    // Preprocessor directives
+    include_directive: $ => seq(directive('include'), field('file', $.string)),
+
+    define_directive: $ => seq(
+      directive('define'),
+      field('name', $.identifier),
+      repeat(WHITE_SPACE),
+      optional(field('value', $.expansion))
+    ),
+    expansion: _ => token(seq(/\S/, repeat(choice(/./, /\\\n/)))),
+
+    ifdef_directive: $ => seq(
+      choice(directive('ifdef'), directive('ifndef')),
+      field('condition', $.identifier),
+      NEWLINE,
+      field('consequence', alias(repeat($._line), $.body)),
+      optional(field('alternative', $.else_directive)),
+      directive('endif'),
+    ),
+
+    else_directive: $ => seq(directive('else'), NEWLINE, repeat($._line)),
+
+    identifier: _ => /[a-zA-Z_][a-zA-Z0-9_]+/,
   },
 });
 

--- a/grammar.js
+++ b/grammar.js
@@ -17,10 +17,11 @@ export default grammar({
 
     _statement: $ => choice(
       $.comment,
-      $.include_directive,
       $.define_directive,
       $.ifdef_directive,
+      $.include_directive,
       $.resource,
+      $.undef_directive,
     ),
 
     comment: _ => token.immediate(seq('!', repeat(ANY_CHAR))),
@@ -65,6 +66,8 @@ export default grammar({
       optional(field('value', $.expansion))
     ),
     expansion: _ => token(seq(/\S/, repeat(choice(/./, /\\\n/)))),
+
+    undef_directive: $ => seq(directive('undef'), field('name', $.identifier)),
 
     ifdef_directive: $ => seq(
       choice(directive('ifdef'), directive('ifndef')),

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "install": "node-gyp-build",
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
-    "test": "node --test bindings/node/*_test.js"
+    "test": "node --test bindings/node/*_test.js",
+    "parse": "tree-sitter parse --quiet --stat examples/*"
   }
 }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -21,6 +21,15 @@
   name: (identifier) @constant
   value: (_)? @string)
 
+(define_function_directive
+  name: (identifier) @function.macro
+  value: (_)? @string)
+
+(parameters
+  (identifier) @variable.parameter)
+
+"..." @variable.parameter.builtin
+
 (undef_directive
   name: (identifier) @constant)
 
@@ -40,6 +49,8 @@
   (resource_value)
 ] @string
 
+(escape_sequence) @string.escape
+
 [
   "*"
   (any_component)
@@ -47,7 +58,11 @@
 
 [
   "."
+  ","
   ":"
 ] @punctuation.delimiter
 
-(escape_sequence) @string.escape
+[
+  "("
+  ")"
+] @punctuation.bracket

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -13,6 +13,8 @@
 [
   "#ifdef"
   "#ifndef"
+  "#elifdef"
+  "#elifndef"
   "#else"
   "#endif"
 ] @keyword.directive

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -19,15 +19,14 @@
   "#elifndef"
   "#else"
   "#endif"
+  (directive)
 ] @keyword.directive
 
 (define_directive
-  name: (identifier) @constant
-  value: (_)? @string)
+  name: (identifier) @constant)
 
 (define_function_directive
-  name: (identifier) @function.macro
-  value: (_)? @string)
+  name: (identifier) @function.macro)
 
 (parameters
   (identifier) @variable.parameter)
@@ -39,6 +38,8 @@
 
 (ifdef_directive
   condition: (identifier) @constant)
+
+(expansion) @markup.raw
 
 (component) @variable.member
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -11,8 +11,10 @@
 ] @keyword.directive.define
 
 [
+  "#if"
   "#ifdef"
   "#ifndef"
+  "#elif"
   "#elifdef"
   "#elifndef"
   "#else"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -5,7 +5,10 @@
 
 "#include" @keyword.import
 
-"#define" @keyword.directive.define
+[
+  "#define"
+  "#undef"
+] @keyword.directive.define
 
 [
   "#ifdef"
@@ -17,6 +20,9 @@
 (define_directive
   name: (identifier) @constant
   value: (_)? @string)
+
+(undef_directive
+  name: (identifier) @constant)
 
 (ifdef_directive
   condition: (identifier) @constant)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -39,10 +39,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "include_directive"
-        },
-        {
-          "type": "SYMBOL",
           "name": "define_directive"
         },
         {
@@ -51,7 +47,15 @@
         },
         {
           "type": "SYMBOL",
+          "name": "include_directive"
+        },
+        {
+          "type": "SYMBOL",
           "name": "resource"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "undef_directive"
         }
       ]
     },
@@ -420,6 +424,47 @@
           }
         ]
       }
+    },
+    "undef_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "#"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[ \\t]"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "undef"
+                }
+              ]
+            }
+          },
+          "named": false,
+          "value": "#undef"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        }
+      ]
     },
     "ifdef_directive": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -43,6 +43,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "define_function_directive"
+        },
+        {
+          "type": "SYMBOL",
           "name": "ifdef_directive"
         },
         {
@@ -373,56 +377,164 @@
           }
         },
         {
-          "type": "REPEAT",
+          "type": "FIELD",
+          "name": "value",
           "content": {
-            "type": "PATTERN",
-            "value": "[ \\t]"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "expansion"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "define_function_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "#"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[ \\t]"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "define"
+                }
+              ]
+            }
+          },
+          "named": false,
+          "value": "#define"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "SYMBOL",
+            "name": "parameters"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "expansion"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "parameters": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "("
           }
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "FIELD",
-              "name": "value",
-              "content": {
-                "type": "SYMBOL",
-                "name": "expansion"
-              }
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "..."
+                    }
+                  ]
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "identifier"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "..."
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
             },
             {
               "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
         }
       ]
     },
     "expansion": {
       "type": "TOKEN",
       "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "PATTERN",
-            "value": "\\S"
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "."
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "\\\\\\n"
-                }
-              ]
-            }
-          }
-        ]
+        "type": "PREC",
+        "value": -1,
+        "content": {
+          "type": "PATTERN",
+          "value": "\\S([^/\\n]|\\/[^*]|\\\\\\r?\\n)*"
+        }
       }
     },
     "undef_directive": {
@@ -650,7 +762,7 @@
     },
     "identifier": {
       "type": "PATTERN",
-      "value": "[a-zA-Z_][a-zA-Z0-9_]+"
+      "value": "[a-zA-Z_][a-zA-Z0-9_]*"
     }
   },
   "extras": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -671,6 +671,17 @@
           }
         },
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "SYMBOL",
+              "name": "elifdef_directive"
+            }
+          }
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
@@ -713,6 +724,87 @@
           },
           "named": false,
           "value": "#endif"
+        }
+      ]
+    },
+    "elifdef_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "TOKEN",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "#"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[ \\t]"
+                      }
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "elifdef"
+                    }
+                  ]
+                }
+              },
+              "named": false,
+              "value": "#elifdef"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "TOKEN",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "#"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[ \\t]"
+                      }
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "elifndef"
+                    }
+                  ]
+                }
+              },
+              "named": false,
+              "value": "#elifndef"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_line"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -63,6 +63,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "simple_directive"
+        },
+        {
+          "type": "SYMBOL",
           "name": "undef_directive"
         }
       ]
@@ -971,9 +975,61 @@
         }
       ]
     },
+    "simple_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "directive"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "expansion"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "directive": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "#"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "PATTERN",
+              "value": "[ \\t]"
+            }
+          },
+          {
+            "type": "PATTERN",
+            "value": "[a-zA-Z_]\\w*"
+          }
+        ]
+      }
+    },
     "identifier": {
       "type": "PATTERN",
-      "value": "[a-zA-Z_][a-zA-Z0-9_]*"
+      "value": "[a-zA-Z_]\\w*"
     }
   },
   "extras": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -47,6 +47,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "if_directive"
+        },
+        {
+          "type": "SYMBOL",
           "name": "ifdef_directive"
         },
         {
@@ -578,6 +582,55 @@
         }
       ]
     },
+    "if_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "#"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[ \\t]"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "if"
+                }
+              ]
+            }
+          },
+          "named": false,
+          "value": "#if"
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expansion"
+          }
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\n"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_if_directive_body"
+        }
+      ]
+    },
     "ifdef_directive": {
       "type": "SEQ",
       "members": [
@@ -655,6 +708,15 @@
           "value": "\\n"
         },
         {
+          "type": "SYMBOL",
+          "name": "_if_directive_body"
+        }
+      ]
+    },
+    "_if_directive_body": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "FIELD",
           "name": "consequence",
           "content": {
@@ -676,8 +738,17 @@
             "type": "FIELD",
             "name": "alternative",
             "content": {
-              "type": "SYMBOL",
-              "name": "elifdef_directive"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "elif_directive"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "elifdef_directive"
+                }
+              ]
             }
           }
         },
@@ -724,6 +795,54 @@
           },
           "named": false,
           "value": "#endif"
+        }
+      ]
+    },
+    "elif_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "TOKEN",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "#"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[ \\t]"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "elif"
+                }
+              ]
+            }
+          },
+          "named": false,
+          "value": "#elif"
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expansion"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_line"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -112,6 +112,182 @@
         ]
       }
     },
+    "resource": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "components"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "PATTERN",
+            "value": "[ \\t]"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "resource_value"
+          }
+        }
+      ]
+    },
+    "components": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "binding"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "component"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "any_component"
+                  }
+                ]
+              },
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "binding"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "component"
+        }
+      ]
+    },
+    "binding": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        }
+      ]
+    },
+    "component": {
+      "type": "PATTERN",
+      "value": "[a-zA-Z0-9_-]+"
+    },
+    "any_component": {
+      "type": "STRING",
+      "value": "?"
+    },
+    "escape_sequence": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "\\"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "n"
+              },
+              {
+                "type": "STRING",
+                "value": "\\"
+              },
+              {
+                "type": "STRING",
+                "value": "\t"
+              },
+              {
+                "type": "STRING",
+                "value": "\n"
+              },
+              {
+                "type": "STRING",
+                "value": " "
+              },
+              {
+                "type": "PATTERN",
+                "value": "[0-7]{3}"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "resource_value": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[^\\x00\\n]"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "escape_sequence"
+          }
+        ]
+      }
+    },
+    "string": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\""
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[^\\n\"]*"
+          },
+          "named": true,
+          "value": "string_content"
+        },
+        {
+          "type": "STRING",
+          "value": "\""
+        }
+      ]
+    },
     "include_directive": {
       "type": "SEQ",
       "members": [
@@ -218,29 +394,32 @@
       ]
     },
     "expansion": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "PATTERN",
-          "value": "\\S"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "."
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\\\\\n"
-              }
-            ]
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "\\S"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "."
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\\\\\n"
+                }
+              ]
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "ifdef_directive": {
       "type": "SEQ",
@@ -427,182 +606,6 @@
     "identifier": {
       "type": "PATTERN",
       "value": "[a-zA-Z_][a-zA-Z0-9_]+"
-    },
-    "resource": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "components"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": ":"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "PATTERN",
-            "value": "[ \\t]"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "value",
-          "content": {
-            "type": "SYMBOL",
-            "name": "resource_value"
-          }
-        }
-      ]
-    },
-    "components": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "binding"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "component"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "any_component"
-                  }
-                ]
-              },
-              {
-                "type": "REPEAT1",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "binding"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "SYMBOL",
-          "name": "component"
-        }
-      ]
-    },
-    "binding": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "."
-        },
-        {
-          "type": "STRING",
-          "value": "*"
-        }
-      ]
-    },
-    "component": {
-      "type": "PATTERN",
-      "value": "[a-zA-Z0-9_-]+"
-    },
-    "any_component": {
-      "type": "STRING",
-      "value": "?"
-    },
-    "escape_sequence": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "\\"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "n"
-              },
-              {
-                "type": "STRING",
-                "value": "\\"
-              },
-              {
-                "type": "STRING",
-                "value": "\t"
-              },
-              {
-                "type": "STRING",
-                "value": "\n"
-              },
-              {
-                "type": "STRING",
-                "value": " "
-              },
-              {
-                "type": "PATTERN",
-                "value": "[0-7]{3}"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "resource_value": {
-      "type": "REPEAT1",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "PATTERN",
-            "value": "[^\\x00\\n]"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "escape_sequence"
-          }
-        ]
-      }
-    },
-    "string": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "\""
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[^\\n\"]*"
-          },
-          "named": true,
-          "value": "string_content"
-        },
-        {
-          "type": "STRING",
-          "value": "\""
-        }
-      ]
     }
   },
   "extras": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -31,6 +31,10 @@
         {
           "type": "resource",
           "named": true
+        },
+        {
+          "type": "undef_directive",
+          "named": true
         }
       ]
     }
@@ -110,6 +114,10 @@
         },
         {
           "type": "resource",
+          "named": true
+        },
+        {
+          "type": "undef_directive",
           "named": true
         }
       ]
@@ -236,6 +244,10 @@
         {
           "type": "resource",
           "named": true
+        },
+        {
+          "type": "undef_directive",
+          "named": true
         }
       ]
     }
@@ -253,6 +265,22 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "undef_directive",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -281,6 +309,10 @@
   },
   {
     "type": "#include",
+    "named": false
+  },
+  {
+    "type": "#undef",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -129,6 +129,56 @@
     }
   },
   {
+    "type": "elifdef_directive",
+    "named": true,
+    "fields": {
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "define_directive",
+          "named": true
+        },
+        {
+          "type": "define_function_directive",
+          "named": true
+        },
+        {
+          "type": "ifdef_directive",
+          "named": true
+        },
+        {
+          "type": "include_directive",
+          "named": true
+        },
+        {
+          "type": "resource",
+          "named": true
+        },
+        {
+          "type": "undef_directive",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "else_directive",
     "named": true,
     "fields": {},
@@ -172,9 +222,13 @@
     "named": true,
     "fields": {
       "alternative": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
+          {
+            "type": "elifdef_directive",
+            "named": true
+          },
           {
             "type": "else_directive",
             "named": true
@@ -352,6 +406,14 @@
   },
   {
     "type": "#define",
+    "named": false
+  },
+  {
+    "type": "#elifdef",
+    "named": false
+  },
+  {
+    "type": "#elifndef",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -116,11 +116,6 @@
     }
   },
   {
-    "type": "expansion",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "ifdef_directive",
     "named": true,
     "fields": {
@@ -314,6 +309,10 @@
   },
   {
     "type": "escape_sequence",
+    "named": true
+  },
+  {
+    "type": "expansion",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -25,6 +25,10 @@
           "named": true
         },
         {
+          "type": "if_directive",
+          "named": true
+        },
+        {
           "type": "ifdef_directive",
           "named": true
         },
@@ -129,6 +133,60 @@
     }
   },
   {
+    "type": "elif_directive",
+    "named": true,
+    "fields": {
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expansion",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "define_directive",
+          "named": true
+        },
+        {
+          "type": "define_function_directive",
+          "named": true
+        },
+        {
+          "type": "if_directive",
+          "named": true
+        },
+        {
+          "type": "ifdef_directive",
+          "named": true
+        },
+        {
+          "type": "include_directive",
+          "named": true
+        },
+        {
+          "type": "resource",
+          "named": true
+        },
+        {
+          "type": "undef_directive",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "elifdef_directive",
     "named": true,
     "fields": {
@@ -157,6 +215,10 @@
         },
         {
           "type": "define_function_directive",
+          "named": true
+        },
+        {
+          "type": "if_directive",
           "named": true
         },
         {
@@ -199,6 +261,10 @@
           "named": true
         },
         {
+          "type": "if_directive",
+          "named": true
+        },
+        {
           "type": "ifdef_directive",
           "named": true
         },
@@ -218,6 +284,50 @@
     }
   },
   {
+    "type": "if_directive",
+    "named": true,
+    "fields": {
+      "alternative": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "elif_directive",
+            "named": true
+          },
+          {
+            "type": "elifdef_directive",
+            "named": true
+          },
+          {
+            "type": "else_directive",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expansion",
+            "named": true
+          }
+        ]
+      },
+      "consequence": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "ifdef_directive",
     "named": true,
     "fields": {
@@ -225,6 +335,10 @@
         "multiple": true,
         "required": false,
         "types": [
+          {
+            "type": "elif_directive",
+            "named": true
+          },
           {
             "type": "elifdef_directive",
             "named": true
@@ -351,6 +465,10 @@
           "named": true
         },
         {
+          "type": "if_directive",
+          "named": true
+        },
+        {
           "type": "ifdef_directive",
           "named": true
         },
@@ -409,6 +527,10 @@
     "named": false
   },
   {
+    "type": "#elif",
+    "named": false
+  },
+  {
     "type": "#elifdef",
     "named": false
   },
@@ -422,6 +544,10 @@
   },
   {
     "type": "#endif",
+    "named": false
+  },
+  {
+    "type": "#if",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -21,6 +21,10 @@
           "named": true
         },
         {
+          "type": "define_function_directive",
+          "named": true
+        },
+        {
           "type": "ifdef_directive",
           "named": true
         },
@@ -89,6 +93,42 @@
     }
   },
   {
+    "type": "define_function_directive",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "parameters",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expansion",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "else_directive",
     "named": true,
     "fields": {},
@@ -102,6 +142,10 @@
         },
         {
           "type": "define_directive",
+          "named": true
+        },
+        {
+          "type": "define_function_directive",
           "named": true
         },
         {
@@ -176,6 +220,21 @@
     }
   },
   {
+    "type": "parameters",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "resource",
     "named": true,
     "fields": {
@@ -231,6 +290,10 @@
         },
         {
           "type": "define_directive",
+          "named": true
+        },
+        {
+          "type": "define_function_directive",
           "named": true
         },
         {
@@ -316,11 +379,27 @@
     "named": false
   },
   {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
+  },
+  {
     "type": "*",
     "named": false
   },
   {
+    "type": ",",
+    "named": false
+  },
+  {
     "type": ".",
+    "named": false
+  },
+  {
+    "type": "...",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -41,6 +41,10 @@
           "named": true
         },
         {
+          "type": "simple_directive",
+          "named": true
+        },
+        {
           "type": "undef_directive",
           "named": true
         }
@@ -180,6 +184,10 @@
           "named": true
         },
         {
+          "type": "simple_directive",
+          "named": true
+        },
+        {
           "type": "undef_directive",
           "named": true
         }
@@ -234,6 +242,10 @@
           "named": true
         },
         {
+          "type": "simple_directive",
+          "named": true
+        },
+        {
           "type": "undef_directive",
           "named": true
         }
@@ -274,6 +286,10 @@
         },
         {
           "type": "resource",
+          "named": true
+        },
+        {
+          "type": "simple_directive",
           "named": true
         },
         {
@@ -481,10 +497,40 @@
           "named": true
         },
         {
+          "type": "simple_directive",
+          "named": true
+        },
+        {
           "type": "undef_directive",
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "simple_directive",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "directive",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expansion",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -604,6 +650,10 @@
   },
   {
     "type": "component",
+    "named": true
+  },
+  {
+    "type": "directive",
     "named": true
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,15 +5,15 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 61
-#define LARGE_STATE_COUNT 8
-#define SYMBOL_COUNT 48
+#define STATE_COUNT 74
+#define LARGE_STATE_COUNT 10
+#define SYMBOL_COUNT 52
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 27
+#define TOKEN_COUNT 29
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 7
-#define MAX_ALIAS_SEQUENCE_LENGTH 6
-#define PRODUCTION_ID_COUNT 12
+#define MAX_ALIAS_SEQUENCE_LENGTH 7
+#define PRODUCTION_ID_COUNT 18
 
 enum ts_symbol_identifiers {
   aux_sym__line_token1 = 1,
@@ -40,30 +40,34 @@ enum ts_symbol_identifiers {
   aux_sym_ifdef_directive_token1 = 22,
   aux_sym_ifdef_directive_token2 = 23,
   aux_sym_ifdef_directive_token3 = 24,
-  aux_sym_else_directive_token1 = 25,
-  sym_identifier = 26,
-  sym_resources = 27,
-  sym__line = 28,
-  sym__statement = 29,
-  sym_resource = 30,
-  sym_components = 31,
-  sym_binding = 32,
-  sym_resource_value = 33,
-  sym_string = 34,
-  sym_include_directive = 35,
-  sym_define_directive = 36,
-  sym_define_function_directive = 37,
-  sym_parameters = 38,
-  sym_undef_directive = 39,
-  sym_ifdef_directive = 40,
-  sym_else_directive = 41,
-  aux_sym_resources_repeat1 = 42,
-  aux_sym_resource_repeat1 = 43,
-  aux_sym_components_repeat1 = 44,
-  aux_sym_components_repeat2 = 45,
-  aux_sym_resource_value_repeat1 = 46,
-  aux_sym_parameters_repeat1 = 47,
-  alias_sym_body = 48,
+  aux_sym_elifdef_directive_token1 = 25,
+  aux_sym_elifdef_directive_token2 = 26,
+  aux_sym_else_directive_token1 = 27,
+  sym_identifier = 28,
+  sym_resources = 29,
+  sym__line = 30,
+  sym__statement = 31,
+  sym_resource = 32,
+  sym_components = 33,
+  sym_binding = 34,
+  sym_resource_value = 35,
+  sym_string = 36,
+  sym_include_directive = 37,
+  sym_define_directive = 38,
+  sym_define_function_directive = 39,
+  sym_parameters = 40,
+  sym_undef_directive = 41,
+  sym_ifdef_directive = 42,
+  sym_elifdef_directive = 43,
+  sym_else_directive = 44,
+  aux_sym_resources_repeat1 = 45,
+  aux_sym_resource_repeat1 = 46,
+  aux_sym_components_repeat1 = 47,
+  aux_sym_components_repeat2 = 48,
+  aux_sym_resource_value_repeat1 = 49,
+  aux_sym_parameters_repeat1 = 50,
+  aux_sym_ifdef_directive_repeat1 = 51,
+  alias_sym_body = 52,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -92,6 +96,8 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_ifdef_directive_token1] = "#ifdef",
   [aux_sym_ifdef_directive_token2] = "#ifndef",
   [aux_sym_ifdef_directive_token3] = "#endif",
+  [aux_sym_elifdef_directive_token1] = "#elifdef",
+  [aux_sym_elifdef_directive_token2] = "#elifndef",
   [aux_sym_else_directive_token1] = "#else",
   [sym_identifier] = "identifier",
   [sym_resources] = "resources",
@@ -108,6 +114,7 @@ static const char * const ts_symbol_names[] = {
   [sym_parameters] = "parameters",
   [sym_undef_directive] = "undef_directive",
   [sym_ifdef_directive] = "ifdef_directive",
+  [sym_elifdef_directive] = "elifdef_directive",
   [sym_else_directive] = "else_directive",
   [aux_sym_resources_repeat1] = "resources_repeat1",
   [aux_sym_resource_repeat1] = "resource_repeat1",
@@ -115,6 +122,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_components_repeat2] = "components_repeat2",
   [aux_sym_resource_value_repeat1] = "resource_value_repeat1",
   [aux_sym_parameters_repeat1] = "parameters_repeat1",
+  [aux_sym_ifdef_directive_repeat1] = "ifdef_directive_repeat1",
   [alias_sym_body] = "body",
 };
 
@@ -144,6 +152,8 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_ifdef_directive_token1] = aux_sym_ifdef_directive_token1,
   [aux_sym_ifdef_directive_token2] = aux_sym_ifdef_directive_token2,
   [aux_sym_ifdef_directive_token3] = aux_sym_ifdef_directive_token3,
+  [aux_sym_elifdef_directive_token1] = aux_sym_elifdef_directive_token1,
+  [aux_sym_elifdef_directive_token2] = aux_sym_elifdef_directive_token2,
   [aux_sym_else_directive_token1] = aux_sym_else_directive_token1,
   [sym_identifier] = sym_identifier,
   [sym_resources] = sym_resources,
@@ -160,6 +170,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_parameters] = sym_parameters,
   [sym_undef_directive] = sym_undef_directive,
   [sym_ifdef_directive] = sym_ifdef_directive,
+  [sym_elifdef_directive] = sym_elifdef_directive,
   [sym_else_directive] = sym_else_directive,
   [aux_sym_resources_repeat1] = aux_sym_resources_repeat1,
   [aux_sym_resource_repeat1] = aux_sym_resource_repeat1,
@@ -167,6 +178,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_components_repeat2] = aux_sym_components_repeat2,
   [aux_sym_resource_value_repeat1] = aux_sym_resource_value_repeat1,
   [aux_sym_parameters_repeat1] = aux_sym_parameters_repeat1,
+  [aux_sym_ifdef_directive_repeat1] = aux_sym_ifdef_directive_repeat1,
   [alias_sym_body] = alias_sym_body,
 };
 
@@ -271,6 +283,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [aux_sym_elifdef_directive_token1] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_elifdef_directive_token2] = {
+    .visible = true,
+    .named = false,
+  },
   [aux_sym_else_directive_token1] = {
     .visible = true,
     .named = false,
@@ -335,6 +355,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_elifdef_directive] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_else_directive] = {
     .visible = true,
     .named = true,
@@ -360,6 +384,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym_parameters_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_ifdef_directive_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -398,10 +426,16 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [5] = {.index = 6, .length = 2},
   [6] = {.index = 8, .length = 3},
   [7] = {.index = 11, .length = 1},
-  [8] = {.index = 12, .length = 2},
-  [9] = {.index = 14, .length = 2},
-  [10] = {.index = 16, .length = 2},
-  [11] = {.index = 18, .length = 3},
+  [8] = {.index = 12, .length = 1},
+  [9] = {.index = 13, .length = 2},
+  [10] = {.index = 15, .length = 2},
+  [11] = {.index = 17, .length = 2},
+  [12] = {.index = 19, .length = 2},
+  [13] = {.index = 21, .length = 2},
+  [14] = {.index = 23, .length = 3},
+  [15] = {.index = 26, .length = 3},
+  [16] = {.index = 29, .length = 3},
+  [17] = {.index = 32, .length = 4},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -425,26 +459,53 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
   [11] =
     {field_condition, 1},
   [12] =
+    {field_alternative, 0},
+  [13] =
     {field_name, 0},
     {field_value, 3},
-  [14] =
+  [15] =
     {field_alternative, 3},
     {field_condition, 1},
-  [16] =
+  [17] =
     {field_condition, 1},
     {field_consequence, 3},
-  [18] =
+  [19] =
+    {field_alternative, 3, .inherited = true},
+    {field_condition, 1},
+  [21] =
+    {field_alternative, 0, .inherited = true},
+    {field_alternative, 1, .inherited = true},
+  [23] =
     {field_alternative, 4},
+    {field_condition, 1},
+    {field_consequence, 3},
+  [26] =
+    {field_alternative, 4, .inherited = true},
+    {field_condition, 1},
+    {field_consequence, 3},
+  [29] =
+    {field_alternative, 3, .inherited = true},
+    {field_alternative, 4},
+    {field_condition, 1},
+  [32] =
+    {field_alternative, 4, .inherited = true},
+    {field_alternative, 5},
     {field_condition, 1},
     {field_consequence, 3},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
-  [10] = {
+  [11] = {
     [3] = alias_sym_body,
   },
-  [11] = {
+  [14] = {
+    [3] = alias_sym_body,
+  },
+  [15] = {
+    [3] = alias_sym_body,
+  },
+  [17] = {
     [3] = alias_sym_body,
   },
 };
@@ -518,6 +579,19 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [58] = 58,
   [59] = 59,
   [60] = 60,
+  [61] = 61,
+  [62] = 62,
+  [63] = 63,
+  [64] = 64,
+  [65] = 65,
+  [66] = 66,
+  [67] = 67,
+  [68] = 68,
+  [69] = 69,
+  [70] = 70,
+  [71] = 71,
+  [72] = 72,
+  [73] = 73,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -525,541 +599,570 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(44);
+      if (eof) ADVANCE(51);
       ADVANCE_MAP(
-        '\n', 45,
-        '!', 48,
-        '(', 83,
-        ')', 86,
-        '*', 67,
-        ',', 85,
-        '.', 66,
-        '/', 93,
-        ':', 63,
-        '?', 69,
-        '\t', 64,
-        ' ', 64,
+        '\n', 52,
+        '!', 55,
+        '(', 90,
+        ')', 93,
+        '*', 74,
+        ',', 92,
+        '.', 73,
+        '/', 100,
+        ':', 70,
+        '?', 76,
+        '\t', 71,
+        ' ', 71,
       );
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(95);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(102);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(45);
-      if (lookahead == '(') ADVANCE(83);
-      if (lookahead == '/') ADVANCE(93);
+      if (lookahead == '\n') ADVANCE(52);
+      if (lookahead == '(') ADVANCE(90);
+      if (lookahead == '/') ADVANCE(100);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(64);
+          lookahead == ' ') ADVANCE(71);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(95);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(102);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(45);
-      if (lookahead == '/') ADVANCE(93);
+      if (lookahead == '\n') ADVANCE(52);
+      if (lookahead == '/') ADVANCE(100);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(64);
+          lookahead == ' ') ADVANCE(71);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(95);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(102);
       END_STATE();
     case 3:
-      if (lookahead == '\n') ADVANCE(45);
-      if (lookahead == '/') ADVANCE(72);
-      if (lookahead == '\\') ADVANCE(73);
+      if (lookahead == '\n') ADVANCE(52);
+      if (lookahead == '/') ADVANCE(79);
+      if (lookahead == '\\') ADVANCE(80);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(64);
-      if (lookahead != 0) ADVANCE(71);
+          lookahead == ' ') ADVANCE(71);
+      if (lookahead != 0) ADVANCE(78);
       END_STATE();
     case 4:
-      if (lookahead == '\r') ADVANCE(60);
-      if (lookahead == '\\') ADVANCE(52);
-      if (lookahead != 0) ADVANCE(59);
+      if (lookahead == '\r') ADVANCE(67);
+      if (lookahead == '\\') ADVANCE(59);
+      if (lookahead != 0) ADVANCE(66);
       END_STATE();
     case 5:
-      if (lookahead == ')') ADVANCE(86);
+      if (lookahead == ')') ADVANCE(93);
       if (lookahead == '.') ADVANCE(11);
       if (lookahead == '/') ADVANCE(6);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(64);
+          lookahead == ' ') ADVANCE(71);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(102);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(111);
       END_STATE();
     case 6:
       if (lookahead == '*') ADVANCE(9);
-      if (lookahead == '/') ADVANCE(59);
+      if (lookahead == '/') ADVANCE(66);
       END_STATE();
     case 7:
       if (lookahead == '*') ADVANCE(7);
-      if (lookahead == '/') ADVANCE(50);
+      if (lookahead == '/') ADVANCE(57);
       if (lookahead != 0) ADVANCE(9);
       END_STATE();
     case 8:
       if (lookahead == '*') ADVANCE(7);
-      if (lookahead != 0) ADVANCE(88);
+      if (lookahead != 0) ADVANCE(95);
       END_STATE();
     case 9:
       if (lookahead == '*') ADVANCE(7);
       if (lookahead != 0) ADVANCE(9);
       END_STATE();
     case 10:
-      if (lookahead == '.') ADVANCE(84);
+      if (lookahead == '.') ADVANCE(91);
       END_STATE();
     case 11:
       if (lookahead == '.') ADVANCE(10);
       END_STATE();
     case 12:
-      if (lookahead == 'c') ADVANCE(35);
+      if (lookahead == 'c') ADVANCE(43);
       END_STATE();
     case 13:
-      if (lookahead == 'd') ADVANCE(19);
-      if (lookahead == 'e') ADVANCE(34);
-      if (lookahead == 'i') ADVANCE(26);
-      if (lookahead == 'u') ADVANCE(36);
+      if (lookahead == 'd') ADVANCE(21);
+      if (lookahead == 'e') ADVANCE(42);
+      if (lookahead == 'i') ADVANCE(30);
+      if (lookahead == 'u') ADVANCE(44);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(13);
       END_STATE();
     case 14:
-      if (lookahead == 'd') ADVANCE(33);
+      if (lookahead == 'd') ADVANCE(41);
       END_STATE();
     case 15:
-      if (lookahead == 'd') ADVANCE(22);
+      if (lookahead == 'd') ADVANCE(24);
       END_STATE();
     case 16:
-      if (lookahead == 'd') ADVANCE(23);
+      if (lookahead == 'd') ADVANCE(25);
       if (lookahead == 'n') ADVANCE(18);
       END_STATE();
     case 17:
-      if (lookahead == 'd') ADVANCE(24);
+      if (lookahead == 'd') ADVANCE(26);
       END_STATE();
     case 18:
-      if (lookahead == 'd') ADVANCE(25);
+      if (lookahead == 'd') ADVANCE(27);
       END_STATE();
     case 19:
-      if (lookahead == 'e') ADVANCE(27);
+      if (lookahead == 'd') ADVANCE(28);
+      if (lookahead == 'n') ADVANCE(20);
       END_STATE();
     case 20:
-      if (lookahead == 'e') ADVANCE(101);
+      if (lookahead == 'd') ADVANCE(29);
       END_STATE();
     case 21:
-      if (lookahead == 'e') ADVANCE(82);
-      END_STATE();
-    case 22:
-      if (lookahead == 'e') ADVANCE(81);
-      END_STATE();
-    case 23:
-      if (lookahead == 'e') ADVANCE(29);
-      END_STATE();
-    case 24:
-      if (lookahead == 'e') ADVANCE(30);
-      END_STATE();
-    case 25:
       if (lookahead == 'e') ADVANCE(31);
       END_STATE();
+    case 22:
+      if (lookahead == 'e') ADVANCE(110);
+      END_STATE();
+    case 23:
+      if (lookahead == 'e') ADVANCE(89);
+      END_STATE();
+    case 24:
+      if (lookahead == 'e') ADVANCE(88);
+      END_STATE();
+    case 25:
+      if (lookahead == 'e') ADVANCE(33);
+      END_STATE();
     case 26:
+      if (lookahead == 'e') ADVANCE(34);
+      END_STATE();
+    case 27:
+      if (lookahead == 'e') ADVANCE(35);
+      END_STATE();
+    case 28:
+      if (lookahead == 'e') ADVANCE(36);
+      END_STATE();
+    case 29:
+      if (lookahead == 'e') ADVANCE(37);
+      END_STATE();
+    case 30:
       if (lookahead == 'f') ADVANCE(16);
       if (lookahead == 'n') ADVANCE(12);
       END_STATE();
-    case 27:
-      if (lookahead == 'f') ADVANCE(32);
-      END_STATE();
-    case 28:
-      if (lookahead == 'f') ADVANCE(100);
-      END_STATE();
-    case 29:
-      if (lookahead == 'f') ADVANCE(98);
-      END_STATE();
-    case 30:
-      if (lookahead == 'f') ADVANCE(97);
-      END_STATE();
     case 31:
-      if (lookahead == 'f') ADVANCE(99);
+      if (lookahead == 'f') ADVANCE(39);
       END_STATE();
     case 32:
-      if (lookahead == 'i') ADVANCE(37);
+      if (lookahead == 'f') ADVANCE(107);
       END_STATE();
     case 33:
-      if (lookahead == 'i') ADVANCE(28);
+      if (lookahead == 'f') ADVANCE(105);
       END_STATE();
     case 34:
-      if (lookahead == 'l') ADVANCE(38);
-      if (lookahead == 'n') ADVANCE(14);
+      if (lookahead == 'f') ADVANCE(104);
       END_STATE();
     case 35:
-      if (lookahead == 'l') ADVANCE(39);
+      if (lookahead == 'f') ADVANCE(106);
       END_STATE();
     case 36:
-      if (lookahead == 'n') ADVANCE(17);
+      if (lookahead == 'f') ADVANCE(108);
       END_STATE();
     case 37:
-      if (lookahead == 'n') ADVANCE(21);
+      if (lookahead == 'f') ADVANCE(109);
       END_STATE();
     case 38:
-      if (lookahead == 's') ADVANCE(20);
+      if (lookahead == 'f') ADVANCE(19);
       END_STATE();
     case 39:
-      if (lookahead == 'u') ADVANCE(15);
+      if (lookahead == 'i') ADVANCE(45);
       END_STATE();
     case 40:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(70);
+      if (lookahead == 'i') ADVANCE(38);
+      if (lookahead == 's') ADVANCE(22);
       END_STATE();
     case 41:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(40);
+      if (lookahead == 'i') ADVANCE(32);
       END_STATE();
     case 42:
-      if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(95);
+      if (lookahead == 'l') ADVANCE(40);
+      if (lookahead == 'n') ADVANCE(14);
       END_STATE();
     case 43:
-      if (eof) ADVANCE(44);
+      if (lookahead == 'l') ADVANCE(46);
+      END_STATE();
+    case 44:
+      if (lookahead == 'n') ADVANCE(17);
+      END_STATE();
+    case 45:
+      if (lookahead == 'n') ADVANCE(23);
+      END_STATE();
+    case 46:
+      if (lookahead == 'u') ADVANCE(15);
+      END_STATE();
+    case 47:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(77);
+      END_STATE();
+    case 48:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(47);
+      END_STATE();
+    case 49:
+      if (lookahead != 0 &&
+          lookahead != '*') ADVANCE(102);
+      END_STATE();
+    case 50:
+      if (eof) ADVANCE(51);
       ADVANCE_MAP(
-        '\n', 45,
-        '!', 49,
-        '"', 74,
+        '\n', 52,
+        '!', 56,
+        '"', 81,
         '#', 13,
-        ')', 86,
-        '*', 67,
-        ',', 85,
-        '.', 66,
+        ')', 93,
+        '*', 74,
+        ',', 92,
+        '.', 73,
         '/', 6,
-        ':', 63,
-        '?', 69,
-        '\t', 64,
-        ' ', 64,
+        ':', 70,
+        '?', 76,
+        '\t', 71,
+        ' ', 71,
       );
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
-      END_STATE();
-    case 44:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 45:
-      ACCEPT_TOKEN(aux_sym__line_token1);
-      END_STATE();
-    case 46:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '\r') ADVANCE(48);
-      if (lookahead == '/') ADVANCE(47);
-      if (lookahead == '\\') ADVANCE(46);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(48);
-      END_STATE();
-    case 47:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '*') ADVANCE(49);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(48);
-      END_STATE();
-    case 48:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '/') ADVANCE(47);
-      if (lookahead == '\\') ADVANCE(46);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(48);
-      END_STATE();
-    case 49:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(49);
-      END_STATE();
-    case 50:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 51:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\n') ADVANCE(59);
-      if (lookahead == '/') ADVANCE(56);
-      if (lookahead == '\\') ADVANCE(92);
-      if (lookahead != 0) ADVANCE(57);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 52:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(60);
-      if (lookahead == '\\') ADVANCE(52);
-      if (lookahead != 0) ADVANCE(59);
+      ACCEPT_TOKEN(aux_sym__line_token1);
       END_STATE();
     case 53:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(58);
-      if (lookahead == '/') ADVANCE(56);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '\r') ADVANCE(55);
+      if (lookahead == '/') ADVANCE(54);
       if (lookahead == '\\') ADVANCE(53);
-      if (lookahead != 0) ADVANCE(57);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(55);
       END_STATE();
     case 54:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(54);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(59);
-      if (lookahead != 0) ADVANCE(55);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '*') ADVANCE(56);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(55);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '"') ADVANCE(59);
-      if (lookahead == '\\') ADVANCE(75);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '/') ADVANCE(54);
+      if (lookahead == '\\') ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(55);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '*') ADVANCE(59);
-      if (lookahead == '\\') ADVANCE(89);
+      ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(57);
+          lookahead != '\n') ADVANCE(56);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '/') ADVANCE(56);
-      if (lookahead == '\\') ADVANCE(92);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(57);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '/') ADVANCE(56);
-      if (lookahead == '\\') ADVANCE(92);
-      if (lookahead != 0) ADVANCE(57);
+      if (lookahead == '\n') ADVANCE(66);
+      if (lookahead == '/') ADVANCE(63);
+      if (lookahead == '\\') ADVANCE(99);
+      if (lookahead != 0) ADVANCE(64);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(4);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(59);
+      if (lookahead == '\r') ADVANCE(67);
+      if (lookahead == '\\') ADVANCE(59);
+      if (lookahead != 0) ADVANCE(66);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(4);
-      if (lookahead != 0) ADVANCE(59);
+      if (lookahead == '\r') ADVANCE(65);
+      if (lookahead == '/') ADVANCE(63);
+      if (lookahead == '\\') ADVANCE(60);
+      if (lookahead != 0) ADVANCE(64);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(75);
+      if (lookahead == '\r') ADVANCE(68);
+      if (lookahead == '\\') ADVANCE(61);
       if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(59);
-      if (lookahead != 0) ADVANCE(55);
+          lookahead == '"') ADVANCE(66);
+      if (lookahead != 0) ADVANCE(62);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '"') ADVANCE(66);
+      if (lookahead == '\\') ADVANCE(82);
       if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(80);
+          lookahead != '\n') ADVANCE(62);
       END_STATE();
     case 63:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '*') ADVANCE(66);
+      if (lookahead == '\\') ADVANCE(96);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(64);
       END_STATE();
     case 64:
-      ACCEPT_TOKEN(aux_sym_resource_token1);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '/') ADVANCE(63);
+      if (lookahead == '\\') ADVANCE(99);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(64);
       END_STATE();
     case 65:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '/') ADVANCE(63);
+      if (lookahead == '\\') ADVANCE(99);
+      if (lookahead != 0) ADVANCE(64);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(4);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(66);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(4);
+      if (lookahead != 0) ADVANCE(66);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(82);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(66);
+      if (lookahead != 0) ADVANCE(62);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(87);
+      END_STATE();
+    case 70:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 71:
+      ACCEPT_TOKEN(aux_sym_resource_token1);
+      END_STATE();
+    case 72:
       ACCEPT_TOKEN(aux_sym_resource_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(80);
+          lookahead != '"') ADVANCE(87);
       END_STATE();
-    case 66:
+    case 73:
       ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
-    case 67:
+    case 74:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 68:
+    case 75:
       ACCEPT_TOKEN(sym_component);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
-    case 69:
+    case 76:
       ACCEPT_TOKEN(sym_any_component);
       END_STATE();
-    case 70:
+    case 77:
       ACCEPT_TOKEN(sym_escape_sequence);
       END_STATE();
-    case 71:
+    case 78:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       END_STATE();
-    case 72:
+    case 79:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       if (lookahead == '*') ADVANCE(9);
-      if (lookahead == '/') ADVANCE(59);
+      if (lookahead == '/') ADVANCE(66);
       END_STATE();
-    case 73:
+    case 80:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == ' ' ||
           lookahead == '\\' ||
-          lookahead == 'n') ADVANCE(70);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(41);
+          lookahead == 'n') ADVANCE(77);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(48);
       END_STATE();
-    case 74:
+    case 81:
       ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
-    case 75:
+    case 82:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '\r') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(54);
+      if (lookahead == '\r') ADVANCE(68);
+      if (lookahead == '\\') ADVANCE(61);
       if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(59);
-      if (lookahead != 0) ADVANCE(55);
+          lookahead == '"') ADVANCE(66);
+      if (lookahead != 0) ADVANCE(62);
       END_STATE();
-    case 76:
+    case 83:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(78);
-      if (lookahead == '/') ADVANCE(55);
+      if (lookahead == '*') ADVANCE(85);
+      if (lookahead == '/') ADVANCE(62);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(80);
+          lookahead != '"') ADVANCE(87);
       END_STATE();
-    case 77:
+    case 84:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(77);
-      if (lookahead == '/') ADVANCE(62);
+      if (lookahead == '*') ADVANCE(84);
+      if (lookahead == '/') ADVANCE(69);
       if (lookahead == '\n' ||
           lookahead == '"') ADVANCE(9);
-      if (lookahead != 0) ADVANCE(78);
+      if (lookahead != 0) ADVANCE(85);
       END_STATE();
-    case 78:
+    case 85:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(77);
+      if (lookahead == '*') ADVANCE(84);
       if (lookahead == '\n' ||
           lookahead == '"') ADVANCE(9);
-      if (lookahead != 0) ADVANCE(78);
+      if (lookahead != 0) ADVANCE(85);
       END_STATE();
-    case 79:
+    case 86:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '/') ADVANCE(76);
+      if (lookahead == '/') ADVANCE(83);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(65);
+          lookahead == ' ') ADVANCE(72);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(80);
+          lookahead != '"') ADVANCE(87);
       END_STATE();
-    case 80:
+    case 87:
       ACCEPT_TOKEN(aux_sym_string_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(80);
-      END_STATE();
-    case 81:
-      ACCEPT_TOKEN(aux_sym_include_directive_token1);
-      END_STATE();
-    case 82:
-      ACCEPT_TOKEN(aux_sym_define_directive_token1);
-      END_STATE();
-    case 83:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      END_STATE();
-    case 84:
-      ACCEPT_TOKEN(anon_sym_DOT_DOT_DOT);
-      END_STATE();
-    case 85:
-      ACCEPT_TOKEN(anon_sym_COMMA);
-      END_STATE();
-    case 86:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      END_STATE();
-    case 87:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(9);
-      if (lookahead == '*') ADVANCE(87);
-      if (lookahead == '/') ADVANCE(50);
-      if (lookahead == '\\') ADVANCE(91);
-      if (lookahead != 0) ADVANCE(88);
+          lookahead != '"') ADVANCE(87);
       END_STATE();
     case 88:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(9);
-      if (lookahead == '*') ADVANCE(87);
-      if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '\\') ADVANCE(91);
-      if (lookahead != 0) ADVANCE(88);
+      ACCEPT_TOKEN(aux_sym_include_directive_token1);
       END_STATE();
     case 89:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(59);
-      if (lookahead == '\r') ADVANCE(51);
-      if (lookahead == '/') ADVANCE(56);
-      if (lookahead == '\\') ADVANCE(53);
-      if (lookahead != 0) ADVANCE(57);
+      ACCEPT_TOKEN(aux_sym_define_directive_token1);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(96);
-      if (lookahead == '/') ADVANCE(42);
-      if (lookahead == '\\') ADVANCE(90);
-      if (lookahead != 0) ADVANCE(95);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 91:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(94);
-      if (lookahead == '*') ADVANCE(87);
-      if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '\\') ADVANCE(91);
-      if (lookahead != 0) ADVANCE(88);
+      ACCEPT_TOKEN(anon_sym_DOT_DOT_DOT);
       END_STATE();
     case 92:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(58);
-      if (lookahead == '/') ADVANCE(56);
-      if (lookahead == '\\') ADVANCE(53);
-      if (lookahead != 0) ADVANCE(57);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 93:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(88);
-      if (lookahead == '/') ADVANCE(56);
-      if (lookahead == '\\') ADVANCE(90);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(95);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(87);
-      if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '\\') ADVANCE(91);
-      if (lookahead != 0) ADVANCE(88);
+      if (lookahead == '\n') ADVANCE(9);
+      if (lookahead == '*') ADVANCE(94);
+      if (lookahead == '/') ADVANCE(57);
+      if (lookahead == '\\') ADVANCE(98);
+      if (lookahead != 0) ADVANCE(95);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '/') ADVANCE(42);
-      if (lookahead == '\\') ADVANCE(90);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(95);
+      if (lookahead == '\n') ADVANCE(9);
+      if (lookahead == '*') ADVANCE(94);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(98);
+      if (lookahead != 0) ADVANCE(95);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '/') ADVANCE(42);
-      if (lookahead == '\\') ADVANCE(90);
-      if (lookahead != 0) ADVANCE(95);
+      if (lookahead == '\n') ADVANCE(66);
+      if (lookahead == '\r') ADVANCE(58);
+      if (lookahead == '/') ADVANCE(63);
+      if (lookahead == '\\') ADVANCE(60);
+      if (lookahead != 0) ADVANCE(64);
       END_STATE();
     case 97:
-      ACCEPT_TOKEN(aux_sym_undef_directive_token1);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\r') ADVANCE(103);
+      if (lookahead == '/') ADVANCE(49);
+      if (lookahead == '\\') ADVANCE(97);
+      if (lookahead != 0) ADVANCE(102);
       END_STATE();
     case 98:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\r') ADVANCE(101);
+      if (lookahead == '*') ADVANCE(94);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(98);
+      if (lookahead != 0) ADVANCE(95);
       END_STATE();
     case 99:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\r') ADVANCE(65);
+      if (lookahead == '/') ADVANCE(63);
+      if (lookahead == '\\') ADVANCE(60);
+      if (lookahead != 0) ADVANCE(64);
       END_STATE();
     case 100:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token3);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '*') ADVANCE(95);
+      if (lookahead == '/') ADVANCE(63);
+      if (lookahead == '\\') ADVANCE(97);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(102);
       END_STATE();
     case 101:
-      ACCEPT_TOKEN(aux_sym_else_directive_token1);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '*') ADVANCE(94);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(98);
+      if (lookahead != 0) ADVANCE(95);
       END_STATE();
     case 102:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '/') ADVANCE(49);
+      if (lookahead == '\\') ADVANCE(97);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(102);
+      END_STATE();
+    case 103:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '/') ADVANCE(49);
+      if (lookahead == '\\') ADVANCE(97);
+      if (lookahead != 0) ADVANCE(102);
+      END_STATE();
+    case 104:
+      ACCEPT_TOKEN(aux_sym_undef_directive_token1);
+      END_STATE();
+    case 105:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token3);
+      END_STATE();
+    case 108:
+      ACCEPT_TOKEN(aux_sym_elifdef_directive_token1);
+      END_STATE();
+    case 109:
+      ACCEPT_TOKEN(aux_sym_elifdef_directive_token2);
+      END_STATE();
+    case 110:
+      ACCEPT_TOKEN(aux_sym_else_directive_token1);
+      END_STATE();
+    case 111:
       ACCEPT_TOKEN(sym_identifier);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(102);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(111);
       END_STATE();
     default:
       return false;
@@ -1068,66 +1171,79 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 43},
-  [2] = {.lex_state = 43},
-  [3] = {.lex_state = 43},
-  [4] = {.lex_state = 43},
-  [5] = {.lex_state = 43},
-  [6] = {.lex_state = 43},
-  [7] = {.lex_state = 43},
-  [8] = {.lex_state = 43},
-  [9] = {.lex_state = 43},
-  [10] = {.lex_state = 43},
-  [11] = {.lex_state = 43},
-  [12] = {.lex_state = 43},
-  [13] = {.lex_state = 43},
-  [14] = {.lex_state = 3},
-  [15] = {.lex_state = 43},
-  [16] = {.lex_state = 43},
-  [17] = {.lex_state = 3},
-  [18] = {.lex_state = 43},
-  [19] = {.lex_state = 43},
-  [20] = {.lex_state = 1},
+  [1] = {.lex_state = 50},
+  [2] = {.lex_state = 50},
+  [3] = {.lex_state = 50},
+  [4] = {.lex_state = 50},
+  [5] = {.lex_state = 50},
+  [6] = {.lex_state = 50},
+  [7] = {.lex_state = 50},
+  [8] = {.lex_state = 50},
+  [9] = {.lex_state = 50},
+  [10] = {.lex_state = 50},
+  [11] = {.lex_state = 50},
+  [12] = {.lex_state = 50},
+  [13] = {.lex_state = 50},
+  [14] = {.lex_state = 50},
+  [15] = {.lex_state = 50},
+  [16] = {.lex_state = 50},
+  [17] = {.lex_state = 50},
+  [18] = {.lex_state = 50},
+  [19] = {.lex_state = 3},
+  [20] = {.lex_state = 50},
   [21] = {.lex_state = 3},
-  [22] = {.lex_state = 3},
-  [23] = {.lex_state = 43},
-  [24] = {.lex_state = 43},
-  [25] = {.lex_state = 43},
-  [26] = {.lex_state = 43},
-  [27] = {.lex_state = 5},
-  [28] = {.lex_state = 43},
-  [29] = {.lex_state = 3},
-  [30] = {.lex_state = 43},
-  [31] = {.lex_state = 2},
-  [32] = {.lex_state = 2},
-  [33] = {.lex_state = 43},
-  [34] = {.lex_state = 5},
-  [35] = {.lex_state = 43},
-  [36] = {.lex_state = 2},
+  [22] = {.lex_state = 50},
+  [23] = {.lex_state = 50},
+  [24] = {.lex_state = 50},
+  [25] = {.lex_state = 3},
+  [26] = {.lex_state = 50},
+  [27] = {.lex_state = 3},
+  [28] = {.lex_state = 1},
+  [29] = {.lex_state = 50},
+  [30] = {.lex_state = 5},
+  [31] = {.lex_state = 50},
+  [32] = {.lex_state = 50},
+  [33] = {.lex_state = 50},
+  [34] = {.lex_state = 3},
+  [35] = {.lex_state = 50},
+  [36] = {.lex_state = 50},
   [37] = {.lex_state = 2},
-  [38] = {.lex_state = 5},
-  [39] = {.lex_state = 5},
-  [40] = {.lex_state = 0},
-  [41] = {.lex_state = 79},
-  [42] = {.lex_state = 0},
-  [43] = {.lex_state = 0},
+  [38] = {.lex_state = 50},
+  [39] = {.lex_state = 2},
+  [40] = {.lex_state = 5},
+  [41] = {.lex_state = 2},
+  [42] = {.lex_state = 2},
+  [43] = {.lex_state = 50},
   [44] = {.lex_state = 0},
-  [45] = {.lex_state = 43},
-  [46] = {.lex_state = 43},
-  [47] = {.lex_state = 0},
-  [48] = {.lex_state = 0},
+  [45] = {.lex_state = 0},
+  [46] = {.lex_state = 50},
+  [47] = {.lex_state = 5},
+  [48] = {.lex_state = 86},
   [49] = {.lex_state = 0},
-  [50] = {.lex_state = 43},
-  [51] = {.lex_state = 0},
+  [50] = {.lex_state = 5},
+  [51] = {.lex_state = 50},
   [52] = {.lex_state = 0},
   [53] = {.lex_state = 0},
-  [54] = {.lex_state = 0},
-  [55] = {.lex_state = 43},
-  [56] = {.lex_state = 5},
+  [54] = {.lex_state = 5},
+  [55] = {.lex_state = 0},
+  [56] = {.lex_state = 50},
   [57] = {.lex_state = 0},
   [58] = {.lex_state = 0},
-  [59] = {.lex_state = 0},
+  [59] = {.lex_state = 50},
   [60] = {.lex_state = 0},
+  [61] = {.lex_state = 0},
+  [62] = {.lex_state = 50},
+  [63] = {.lex_state = 0},
+  [64] = {.lex_state = 0},
+  [65] = {.lex_state = 0},
+  [66] = {.lex_state = 0},
+  [67] = {.lex_state = 5},
+  [68] = {.lex_state = 0},
+  [69] = {.lex_state = 0},
+  [70] = {.lex_state = 0},
+  [71] = {.lex_state = 50},
+  [72] = {.lex_state = 0},
+  [73] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1148,20 +1264,20 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_expansion] = ACTIONS(1),
   },
   [1] = {
-    [sym_resources] = STATE(43),
-    [sym__line] = STATE(8),
-    [sym__statement] = STATE(59),
-    [sym_resource] = STATE(59),
-    [sym_components] = STATE(46),
-    [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(59),
-    [sym_define_directive] = STATE(59),
-    [sym_define_function_directive] = STATE(59),
-    [sym_undef_directive] = STATE(59),
-    [sym_ifdef_directive] = STATE(59),
-    [aux_sym_resources_repeat1] = STATE(5),
-    [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(26),
+    [sym_resources] = STATE(68),
+    [sym__line] = STATE(10),
+    [sym__statement] = STATE(65),
+    [sym_resource] = STATE(65),
+    [sym_components] = STATE(51),
+    [sym_binding] = STATE(12),
+    [sym_include_directive] = STATE(65),
+    [sym_define_directive] = STATE(65),
+    [sym_define_function_directive] = STATE(65),
+    [sym_undef_directive] = STATE(65),
+    [sym_ifdef_directive] = STATE(65),
+    [aux_sym_resources_repeat1] = STATE(7),
+    [aux_sym_components_repeat1] = STATE(12),
+    [aux_sym_components_repeat2] = STATE(31),
     [ts_builtin_sym_end] = ACTIONS(5),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
@@ -1178,51 +1294,57 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_ifdef_directive_token2] = ACTIONS(23),
   },
   [2] = {
-    [sym__line] = STATE(8),
-    [sym__statement] = STATE(59),
-    [sym_resource] = STATE(59),
-    [sym_components] = STATE(46),
-    [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(59),
-    [sym_define_directive] = STATE(59),
-    [sym_define_function_directive] = STATE(59),
-    [sym_undef_directive] = STATE(59),
-    [sym_ifdef_directive] = STATE(59),
-    [aux_sym_resources_repeat1] = STATE(2),
-    [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(26),
-    [ts_builtin_sym_end] = ACTIONS(25),
-    [aux_sym__line_token1] = ACTIONS(27),
-    [sym_comment] = ACTIONS(30),
+    [sym__line] = STATE(10),
+    [sym__statement] = STATE(65),
+    [sym_resource] = STATE(65),
+    [sym_components] = STATE(51),
+    [sym_binding] = STATE(12),
+    [sym_include_directive] = STATE(65),
+    [sym_define_directive] = STATE(65),
+    [sym_define_function_directive] = STATE(65),
+    [sym_undef_directive] = STATE(65),
+    [sym_ifdef_directive] = STATE(65),
+    [sym_elifdef_directive] = STATE(26),
+    [sym_else_directive] = STATE(59),
+    [aux_sym_resources_repeat1] = STATE(4),
+    [aux_sym_components_repeat1] = STATE(12),
+    [aux_sym_components_repeat2] = STATE(31),
+    [aux_sym_ifdef_directive_repeat1] = STATE(13),
+    [aux_sym__line_token1] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(33),
-    [anon_sym_STAR] = ACTIONS(33),
-    [sym_component] = ACTIONS(36),
-    [sym_any_component] = ACTIONS(39),
-    [aux_sym_include_directive_token1] = ACTIONS(42),
-    [aux_sym_define_directive_token1] = ACTIONS(45),
-    [aux_sym_undef_directive_token1] = ACTIONS(48),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(51),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(51),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
     [aux_sym_ifdef_directive_token3] = ACTIONS(25),
-    [aux_sym_else_directive_token1] = ACTIONS(25),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(27),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(27),
+    [aux_sym_else_directive_token1] = ACTIONS(29),
   },
   [3] = {
-    [sym__line] = STATE(8),
-    [sym__statement] = STATE(59),
-    [sym_resource] = STATE(59),
-    [sym_components] = STATE(46),
-    [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(59),
-    [sym_define_directive] = STATE(59),
-    [sym_define_function_directive] = STATE(59),
-    [sym_undef_directive] = STATE(59),
-    [sym_ifdef_directive] = STATE(59),
-    [sym_else_directive] = STATE(50),
-    [aux_sym_resources_repeat1] = STATE(4),
-    [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(26),
+    [sym__line] = STATE(10),
+    [sym__statement] = STATE(65),
+    [sym_resource] = STATE(65),
+    [sym_components] = STATE(51),
+    [sym_binding] = STATE(12),
+    [sym_include_directive] = STATE(65),
+    [sym_define_directive] = STATE(65),
+    [sym_define_function_directive] = STATE(65),
+    [sym_undef_directive] = STATE(65),
+    [sym_ifdef_directive] = STATE(65),
+    [sym_elifdef_directive] = STATE(26),
+    [sym_else_directive] = STATE(46),
+    [aux_sym_resources_repeat1] = STATE(2),
+    [aux_sym_components_repeat1] = STATE(12),
+    [aux_sym_components_repeat2] = STATE(31),
+    [aux_sym_ifdef_directive_repeat1] = STATE(14),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1236,83 +1358,58 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_undef_directive_token1] = ACTIONS(21),
     [aux_sym_ifdef_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token2] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(54),
-    [aux_sym_else_directive_token1] = ACTIONS(56),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(31),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(27),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(27),
+    [aux_sym_else_directive_token1] = ACTIONS(29),
   },
   [4] = {
-    [sym__line] = STATE(8),
-    [sym__statement] = STATE(59),
-    [sym_resource] = STATE(59),
-    [sym_components] = STATE(46),
-    [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(59),
-    [sym_define_directive] = STATE(59),
-    [sym_define_function_directive] = STATE(59),
-    [sym_undef_directive] = STATE(59),
-    [sym_ifdef_directive] = STATE(59),
-    [sym_else_directive] = STATE(55),
-    [aux_sym_resources_repeat1] = STATE(2),
-    [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(26),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [sym__line] = STATE(10),
+    [sym__statement] = STATE(65),
+    [sym_resource] = STATE(65),
+    [sym_components] = STATE(51),
+    [sym_binding] = STATE(12),
+    [sym_include_directive] = STATE(65),
+    [sym_define_directive] = STATE(65),
+    [sym_define_function_directive] = STATE(65),
+    [sym_undef_directive] = STATE(65),
+    [sym_ifdef_directive] = STATE(65),
+    [aux_sym_resources_repeat1] = STATE(4),
+    [aux_sym_components_repeat1] = STATE(12),
+    [aux_sym_components_repeat2] = STATE(31),
+    [ts_builtin_sym_end] = ACTIONS(33),
+    [aux_sym__line_token1] = ACTIONS(35),
+    [sym_comment] = ACTIONS(38),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(11),
-    [sym_component] = ACTIONS(13),
-    [sym_any_component] = ACTIONS(15),
-    [aux_sym_include_directive_token1] = ACTIONS(17),
-    [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(58),
-    [aux_sym_else_directive_token1] = ACTIONS(56),
+    [anon_sym_DOT] = ACTIONS(41),
+    [anon_sym_STAR] = ACTIONS(41),
+    [sym_component] = ACTIONS(44),
+    [sym_any_component] = ACTIONS(47),
+    [aux_sym_include_directive_token1] = ACTIONS(50),
+    [aux_sym_define_directive_token1] = ACTIONS(53),
+    [aux_sym_undef_directive_token1] = ACTIONS(56),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(59),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(59),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(33),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(33),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(33),
+    [aux_sym_else_directive_token1] = ACTIONS(33),
   },
   [5] = {
-    [sym__line] = STATE(8),
-    [sym__statement] = STATE(59),
-    [sym_resource] = STATE(59),
-    [sym_components] = STATE(46),
-    [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(59),
-    [sym_define_directive] = STATE(59),
-    [sym_define_function_directive] = STATE(59),
-    [sym_undef_directive] = STATE(59),
-    [sym_ifdef_directive] = STATE(59),
-    [aux_sym_resources_repeat1] = STATE(2),
-    [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(26),
-    [ts_builtin_sym_end] = ACTIONS(60),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
-    [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(11),
-    [sym_component] = ACTIONS(13),
-    [sym_any_component] = ACTIONS(15),
-    [aux_sym_include_directive_token1] = ACTIONS(17),
-    [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
-  },
-  [6] = {
-    [sym__line] = STATE(8),
-    [sym__statement] = STATE(59),
-    [sym_resource] = STATE(59),
-    [sym_components] = STATE(46),
-    [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(59),
-    [sym_define_directive] = STATE(59),
-    [sym_define_function_directive] = STATE(59),
-    [sym_undef_directive] = STATE(59),
-    [sym_ifdef_directive] = STATE(59),
-    [aux_sym_resources_repeat1] = STATE(7),
-    [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(26),
+    [sym__line] = STATE(10),
+    [sym__statement] = STATE(65),
+    [sym_resource] = STATE(65),
+    [sym_components] = STATE(51),
+    [sym_binding] = STATE(12),
+    [sym_include_directive] = STATE(65),
+    [sym_define_directive] = STATE(65),
+    [sym_define_function_directive] = STATE(65),
+    [sym_undef_directive] = STATE(65),
+    [sym_ifdef_directive] = STATE(65),
+    [aux_sym_resources_repeat1] = STATE(6),
+    [aux_sym_components_repeat1] = STATE(12),
+    [aux_sym_components_repeat2] = STATE(31),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1327,21 +1424,24 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_ifdef_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token2] = ACTIONS(23),
     [aux_sym_ifdef_directive_token3] = ACTIONS(62),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(62),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(62),
+    [aux_sym_else_directive_token1] = ACTIONS(62),
   },
-  [7] = {
-    [sym__line] = STATE(8),
-    [sym__statement] = STATE(59),
-    [sym_resource] = STATE(59),
-    [sym_components] = STATE(46),
-    [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(59),
-    [sym_define_directive] = STATE(59),
-    [sym_define_function_directive] = STATE(59),
-    [sym_undef_directive] = STATE(59),
-    [sym_ifdef_directive] = STATE(59),
-    [aux_sym_resources_repeat1] = STATE(2),
-    [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(26),
+  [6] = {
+    [sym__line] = STATE(10),
+    [sym__statement] = STATE(65),
+    [sym_resource] = STATE(65),
+    [sym_components] = STATE(51),
+    [sym_binding] = STATE(12),
+    [sym_include_directive] = STATE(65),
+    [sym_define_directive] = STATE(65),
+    [sym_define_function_directive] = STATE(65),
+    [sym_undef_directive] = STATE(65),
+    [sym_ifdef_directive] = STATE(65),
+    [aux_sym_resources_repeat1] = STATE(4),
+    [aux_sym_components_repeat1] = STATE(12),
+    [aux_sym_components_repeat2] = STATE(31),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1356,6 +1456,96 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_ifdef_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token2] = ACTIONS(23),
     [aux_sym_ifdef_directive_token3] = ACTIONS(64),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(64),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(64),
+    [aux_sym_else_directive_token1] = ACTIONS(64),
+  },
+  [7] = {
+    [sym__line] = STATE(10),
+    [sym__statement] = STATE(65),
+    [sym_resource] = STATE(65),
+    [sym_components] = STATE(51),
+    [sym_binding] = STATE(12),
+    [sym_include_directive] = STATE(65),
+    [sym_define_directive] = STATE(65),
+    [sym_define_function_directive] = STATE(65),
+    [sym_undef_directive] = STATE(65),
+    [sym_ifdef_directive] = STATE(65),
+    [aux_sym_resources_repeat1] = STATE(4),
+    [aux_sym_components_repeat1] = STATE(12),
+    [aux_sym_components_repeat2] = STATE(31),
+    [ts_builtin_sym_end] = ACTIONS(66),
+    [aux_sym__line_token1] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
+    [sym_preprocessor_comment] = ACTIONS(3),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
+  },
+  [8] = {
+    [sym__line] = STATE(10),
+    [sym__statement] = STATE(65),
+    [sym_resource] = STATE(65),
+    [sym_components] = STATE(51),
+    [sym_binding] = STATE(12),
+    [sym_include_directive] = STATE(65),
+    [sym_define_directive] = STATE(65),
+    [sym_define_function_directive] = STATE(65),
+    [sym_undef_directive] = STATE(65),
+    [sym_ifdef_directive] = STATE(65),
+    [aux_sym_resources_repeat1] = STATE(9),
+    [aux_sym_components_repeat1] = STATE(12),
+    [aux_sym_components_repeat2] = STATE(31),
+    [aux_sym__line_token1] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
+    [sym_preprocessor_comment] = ACTIONS(3),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(68),
+  },
+  [9] = {
+    [sym__line] = STATE(10),
+    [sym__statement] = STATE(65),
+    [sym_resource] = STATE(65),
+    [sym_components] = STATE(51),
+    [sym_binding] = STATE(12),
+    [sym_include_directive] = STATE(65),
+    [sym_define_directive] = STATE(65),
+    [sym_define_function_directive] = STATE(65),
+    [sym_undef_directive] = STATE(65),
+    [sym_ifdef_directive] = STATE(65),
+    [aux_sym_resources_repeat1] = STATE(4),
+    [aux_sym_components_repeat1] = STATE(12),
+    [aux_sym_components_repeat2] = STATE(31),
+    [aux_sym__line_token1] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
+    [sym_preprocessor_comment] = ACTIONS(3),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(70),
   },
 };
 
@@ -1364,7 +1554,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(66), 14,
+    ACTIONS(72), 16,
       ts_builtin_sym_end,
       aux_sym__line_token1,
       sym_comment,
@@ -1378,12 +1568,14 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
       aux_sym_ifdef_directive_token3,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
       aux_sym_else_directive_token1,
-  [21] = 2,
+  [23] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(68), 14,
+    ACTIONS(74), 16,
       ts_builtin_sym_end,
       aux_sym__line_token1,
       sym_comment,
@@ -1397,13 +1589,15 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
       aux_sym_ifdef_directive_token3,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
       aux_sym_else_directive_token1,
-  [42] = 6,
+  [46] = 6,
     ACTIONS(15), 1,
       sym_any_component,
-    ACTIONS(70), 1,
+    ACTIONS(76), 1,
       sym_component,
-    STATE(25), 1,
+    STATE(33), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1411,64 +1605,85 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(12), 2,
+    STATE(16), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [64] = 4,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    ACTIONS(72), 2,
-      sym_component,
-      sym_any_component,
-    STATE(12), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [81] = 4,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(74), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    ACTIONS(77), 2,
-      sym_component,
-      sym_any_component,
-    STATE(12), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [98] = 4,
-    ACTIONS(79), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    STATE(11), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [114] = 7,
-    ACTIONS(3), 1,
-      sym_preprocessor_comment,
-    ACTIONS(81), 1,
-      aux_sym_resource_token1,
-    ACTIONS(83), 1,
-      sym_escape_sequence,
-    ACTIONS(85), 1,
-      aux_sym_resource_value_token1,
+  [68] = 7,
+    ACTIONS(29), 1,
+      aux_sym_else_directive_token1,
+    ACTIONS(78), 1,
+      aux_sym_ifdef_directive_token3,
     STATE(17), 1,
-      aux_sym_resource_repeat1,
-    STATE(21), 1,
-      aux_sym_resource_value_repeat1,
-    STATE(40), 1,
-      sym_resource_value,
-  [136] = 4,
-    ACTIONS(87), 1,
+      aux_sym_ifdef_directive_repeat1,
+    STATE(26), 1,
+      sym_elifdef_directive,
+    STATE(71), 1,
+      sym_else_directive,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(27), 2,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
+  [92] = 7,
+    ACTIONS(29), 1,
+      aux_sym_else_directive_token1,
+    ACTIONS(80), 1,
+      aux_sym_ifdef_directive_token3,
+    STATE(17), 1,
+      aux_sym_ifdef_directive_repeat1,
+    STATE(26), 1,
+      sym_elifdef_directive,
+    STATE(62), 1,
+      sym_else_directive,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(27), 2,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
+  [116] = 4,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    ACTIONS(82), 2,
+      sym_component,
+      sym_any_component,
+    STATE(16), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [133] = 4,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(84), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    ACTIONS(87), 2,
+      sym_component,
+      sym_any_component,
+    STATE(16), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [150] = 5,
+    STATE(17), 1,
+      aux_sym_ifdef_directive_repeat1,
+    STATE(26), 1,
+      sym_elifdef_directive,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(89), 2,
+      aux_sym_ifdef_directive_token3,
+      aux_sym_else_directive_token1,
+    ACTIONS(91), 2,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
+  [169] = 4,
+    ACTIONS(94), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1476,358 +1691,436 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(11), 2,
+    STATE(15), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [152] = 4,
-    ACTIONS(89), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    STATE(11), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [168] = 7,
+  [185] = 7,
     ACTIONS(3), 1,
       sym_preprocessor_comment,
-    ACTIONS(83), 1,
-      sym_escape_sequence,
-    ACTIONS(85), 1,
-      aux_sym_resource_value_token1,
-    ACTIONS(91), 1,
+    ACTIONS(96), 1,
       aux_sym_resource_token1,
+    ACTIONS(98), 1,
+      sym_escape_sequence,
+    ACTIONS(100), 1,
+      aux_sym_resource_value_token1,
     STATE(21), 1,
-      aux_sym_resource_value_repeat1,
-    STATE(29), 1,
       aux_sym_resource_repeat1,
-    STATE(58), 1,
+    STATE(25), 1,
+      aux_sym_resource_value_repeat1,
+    STATE(45), 1,
       sym_resource_value,
-  [190] = 3,
+  [207] = 4,
+    ACTIONS(102), 1,
+      anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(11), 2,
+    STATE(15), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [203] = 2,
+  [223] = 7,
+    ACTIONS(3), 1,
+      sym_preprocessor_comment,
+    ACTIONS(98), 1,
+      sym_escape_sequence,
+    ACTIONS(100), 1,
+      aux_sym_resource_value_token1,
+    ACTIONS(104), 1,
+      aux_sym_resource_token1,
+    STATE(25), 1,
+      aux_sym_resource_value_repeat1,
+    STATE(34), 1,
+      aux_sym_resource_repeat1,
+    STATE(49), 1,
+      sym_resource_value,
+  [245] = 4,
+    ACTIONS(106), 1,
+      anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(93), 4,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    STATE(15), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [261] = 3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    STATE(15), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [274] = 2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(108), 4,
       anon_sym_DOT,
       anon_sym_STAR,
       sym_component,
       sym_any_component,
-  [214] = 5,
-    ACTIONS(95), 1,
+  [285] = 5,
+    ACTIONS(110), 1,
       aux_sym__line_token1,
-    ACTIONS(97), 1,
+    ACTIONS(112), 1,
+      sym_escape_sequence,
+    ACTIONS(114), 1,
+      aux_sym_resource_value_token1,
+    STATE(27), 1,
+      aux_sym_resource_value_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [302] = 2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(116), 4,
+      aux_sym_ifdef_directive_token3,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
+      aux_sym_else_directive_token1,
+  [313] = 5,
+    ACTIONS(118), 1,
+      aux_sym__line_token1,
+    ACTIONS(120), 1,
+      sym_escape_sequence,
+    ACTIONS(123), 1,
+      aux_sym_resource_value_token1,
+    STATE(27), 1,
+      aux_sym_resource_value_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [330] = 5,
+    ACTIONS(126), 1,
+      aux_sym__line_token1,
+    ACTIONS(128), 1,
       anon_sym_LPAREN,
-    ACTIONS(99), 1,
+    ACTIONS(130), 1,
       sym_expansion,
-    STATE(32), 1,
+    STATE(42), 1,
       sym_parameters,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [231] = 5,
-    ACTIONS(101), 1,
-      aux_sym__line_token1,
-    ACTIONS(103), 1,
-      sym_escape_sequence,
-    ACTIONS(105), 1,
-      aux_sym_resource_value_token1,
-    STATE(22), 1,
-      aux_sym_resource_value_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [248] = 5,
-    ACTIONS(107), 1,
-      aux_sym__line_token1,
-    ACTIONS(109), 1,
-      sym_escape_sequence,
-    ACTIONS(112), 1,
-      aux_sym_resource_value_token1,
-    STATE(22), 1,
-      aux_sym_resource_value_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [265] = 3,
-    STATE(23), 1,
-      aux_sym_components_repeat2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(115), 2,
-      sym_component,
-      sym_any_component,
-  [277] = 4,
-    ACTIONS(118), 1,
+  [347] = 4,
+    ACTIONS(132), 1,
       anon_sym_COMMA,
-    ACTIONS(121), 1,
+    ACTIONS(135), 1,
       anon_sym_RPAREN,
-    STATE(24), 1,
+    STATE(29), 1,
       aux_sym_parameters_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [291] = 4,
-    ACTIONS(15), 1,
-      sym_any_component,
-    ACTIONS(123), 1,
-      sym_component,
-    STATE(23), 1,
-      aux_sym_components_repeat2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [305] = 4,
-    ACTIONS(15), 1,
-      sym_any_component,
-    ACTIONS(70), 1,
-      sym_component,
-    STATE(23), 1,
-      aux_sym_components_repeat2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [319] = 3,
-    ACTIONS(127), 1,
+  [361] = 3,
+    ACTIONS(139), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(125), 2,
+    ACTIONS(137), 2,
       anon_sym_DOT_DOT_DOT,
       sym_identifier,
-  [331] = 4,
-    ACTIONS(129), 1,
+  [373] = 4,
+    ACTIONS(15), 1,
+      sym_any_component,
+    ACTIONS(76), 1,
+      sym_component,
+    STATE(35), 1,
+      aux_sym_components_repeat2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [387] = 4,
+    ACTIONS(141), 1,
       anon_sym_COMMA,
-    ACTIONS(131), 1,
+    ACTIONS(143), 1,
       anon_sym_RPAREN,
-    STATE(30), 1,
+    STATE(36), 1,
       aux_sym_parameters_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [345] = 5,
+  [401] = 4,
+    ACTIONS(15), 1,
+      sym_any_component,
+    ACTIONS(145), 1,
+      sym_component,
+    STATE(35), 1,
+      aux_sym_components_repeat2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [415] = 5,
     ACTIONS(3), 1,
       sym_preprocessor_comment,
-    ACTIONS(133), 1,
+    ACTIONS(147), 1,
       aux_sym_resource_token1,
-    ACTIONS(136), 1,
+    ACTIONS(150), 1,
       sym_escape_sequence,
-    ACTIONS(138), 1,
+    ACTIONS(152), 1,
       aux_sym_resource_value_token1,
-    STATE(29), 1,
+    STATE(34), 1,
       aux_sym_resource_repeat1,
-  [361] = 4,
-    ACTIONS(129), 1,
+  [431] = 3,
+    STATE(35), 1,
+      aux_sym_components_repeat2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(154), 2,
+      sym_component,
+      sym_any_component,
+  [443] = 4,
+    ACTIONS(141), 1,
       anon_sym_COMMA,
-    ACTIONS(140), 1,
+    ACTIONS(157), 1,
       anon_sym_RPAREN,
-    STATE(24), 1,
+    STATE(29), 1,
       aux_sym_parameters_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [375] = 3,
-    ACTIONS(142), 1,
+  [457] = 3,
+    ACTIONS(159), 1,
       aux_sym__line_token1,
-    ACTIONS(144), 1,
+    ACTIONS(161), 1,
       sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [386] = 3,
-    ACTIONS(146), 1,
-      aux_sym__line_token1,
-    ACTIONS(148), 1,
-      sym_expansion,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [397] = 2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(121), 2,
-      anon_sym_COMMA,
-      anon_sym_RPAREN,
-  [406] = 2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(150), 2,
-      anon_sym_DOT_DOT_DOT,
-      sym_identifier,
-  [415] = 3,
-    ACTIONS(152), 1,
+  [468] = 3,
+    ACTIONS(163), 1,
       anon_sym_DQUOTE,
-    STATE(42), 1,
+    STATE(55), 1,
       sym_string,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [426] = 3,
-    ACTIONS(154), 1,
+  [479] = 3,
+    ACTIONS(165), 1,
       aux_sym__line_token1,
-    ACTIONS(156), 1,
+    ACTIONS(167), 1,
       sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [437] = 3,
-    ACTIONS(158), 1,
+  [490] = 2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(169), 2,
+      anon_sym_DOT_DOT_DOT,
+      sym_identifier,
+  [499] = 3,
+    ACTIONS(171), 1,
       aux_sym__line_token1,
-    ACTIONS(160), 1,
+    ACTIONS(173), 1,
       sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [448] = 2,
-    ACTIONS(162), 1,
-      sym_identifier,
+  [510] = 3,
+    ACTIONS(175), 1,
+      aux_sym__line_token1,
+    ACTIONS(177), 1,
+      sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [456] = 2,
-    ACTIONS(164), 1,
-      sym_identifier,
+  [521] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [464] = 2,
-    ACTIONS(166), 1,
+    ACTIONS(135), 2,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+  [530] = 2,
+    ACTIONS(179), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [472] = 2,
-    ACTIONS(170), 1,
+  [538] = 2,
+    ACTIONS(181), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [546] = 2,
+    ACTIONS(183), 1,
+      aux_sym_ifdef_directive_token3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [554] = 2,
+    ACTIONS(185), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [562] = 2,
+    ACTIONS(189), 1,
       aux_sym_string_token1,
-    ACTIONS(168), 2,
+    ACTIONS(187), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [480] = 2,
-    ACTIONS(172), 1,
+  [570] = 2,
+    ACTIONS(191), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [488] = 2,
-    ACTIONS(174), 1,
-      ts_builtin_sym_end,
+  [578] = 2,
+    ACTIONS(193), 1,
+      sym_identifier,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [496] = 2,
-    ACTIONS(176), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [504] = 2,
-    ACTIONS(178), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [512] = 2,
-    ACTIONS(180), 1,
+  [586] = 2,
+    ACTIONS(195), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [520] = 2,
-    ACTIONS(182), 1,
+  [594] = 2,
+    ACTIONS(197), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [528] = 2,
-    ACTIONS(184), 1,
+  [602] = 2,
+    ACTIONS(199), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [536] = 2,
-    ACTIONS(186), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [544] = 2,
-    ACTIONS(188), 1,
-      aux_sym_ifdef_directive_token3,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [552] = 2,
-    ACTIONS(190), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [560] = 2,
-    ACTIONS(192), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [568] = 2,
-    ACTIONS(194), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [576] = 2,
-    ACTIONS(196), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [584] = 2,
-    ACTIONS(198), 1,
-      aux_sym_ifdef_directive_token3,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [592] = 2,
-    ACTIONS(200), 1,
+  [610] = 2,
+    ACTIONS(201), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [600] = 2,
-    ACTIONS(202), 1,
+  [618] = 2,
+    ACTIONS(203), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [608] = 2,
-    ACTIONS(204), 1,
+  [626] = 2,
+    ACTIONS(205), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [634] = 2,
+    ACTIONS(207), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [616] = 2,
-    ACTIONS(206), 1,
+  [642] = 2,
+    ACTIONS(209), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [624] = 2,
-    ACTIONS(208), 1,
+  [650] = 2,
+    ACTIONS(211), 1,
+      aux_sym_ifdef_directive_token3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [658] = 2,
+    ACTIONS(213), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [666] = 2,
+    ACTIONS(215), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [674] = 2,
+    ACTIONS(217), 1,
+      aux_sym_ifdef_directive_token3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [682] = 2,
+    ACTIONS(219), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [690] = 2,
+    ACTIONS(221), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [698] = 2,
+    ACTIONS(223), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [706] = 2,
+    ACTIONS(225), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [714] = 2,
+    ACTIONS(227), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [722] = 2,
+    ACTIONS(229), 1,
+      ts_builtin_sym_end,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [730] = 2,
+    ACTIONS(231), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [738] = 2,
+    ACTIONS(233), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [746] = 2,
+    ACTIONS(235), 1,
+      aux_sym_ifdef_directive_token3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [754] = 2,
+    ACTIONS(237), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [762] = 2,
+    ACTIONS(239), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1835,59 +2128,70 @@ static const uint16_t ts_small_parse_table[] = {
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(8)] = 0,
-  [SMALL_STATE(9)] = 21,
-  [SMALL_STATE(10)] = 42,
-  [SMALL_STATE(11)] = 64,
-  [SMALL_STATE(12)] = 81,
-  [SMALL_STATE(13)] = 98,
-  [SMALL_STATE(14)] = 114,
-  [SMALL_STATE(15)] = 136,
-  [SMALL_STATE(16)] = 152,
-  [SMALL_STATE(17)] = 168,
-  [SMALL_STATE(18)] = 190,
-  [SMALL_STATE(19)] = 203,
-  [SMALL_STATE(20)] = 214,
-  [SMALL_STATE(21)] = 231,
-  [SMALL_STATE(22)] = 248,
-  [SMALL_STATE(23)] = 265,
-  [SMALL_STATE(24)] = 277,
-  [SMALL_STATE(25)] = 291,
-  [SMALL_STATE(26)] = 305,
-  [SMALL_STATE(27)] = 319,
-  [SMALL_STATE(28)] = 331,
-  [SMALL_STATE(29)] = 345,
+  [SMALL_STATE(10)] = 0,
+  [SMALL_STATE(11)] = 23,
+  [SMALL_STATE(12)] = 46,
+  [SMALL_STATE(13)] = 68,
+  [SMALL_STATE(14)] = 92,
+  [SMALL_STATE(15)] = 116,
+  [SMALL_STATE(16)] = 133,
+  [SMALL_STATE(17)] = 150,
+  [SMALL_STATE(18)] = 169,
+  [SMALL_STATE(19)] = 185,
+  [SMALL_STATE(20)] = 207,
+  [SMALL_STATE(21)] = 223,
+  [SMALL_STATE(22)] = 245,
+  [SMALL_STATE(23)] = 261,
+  [SMALL_STATE(24)] = 274,
+  [SMALL_STATE(25)] = 285,
+  [SMALL_STATE(26)] = 302,
+  [SMALL_STATE(27)] = 313,
+  [SMALL_STATE(28)] = 330,
+  [SMALL_STATE(29)] = 347,
   [SMALL_STATE(30)] = 361,
-  [SMALL_STATE(31)] = 375,
-  [SMALL_STATE(32)] = 386,
-  [SMALL_STATE(33)] = 397,
-  [SMALL_STATE(34)] = 406,
-  [SMALL_STATE(35)] = 415,
-  [SMALL_STATE(36)] = 426,
-  [SMALL_STATE(37)] = 437,
-  [SMALL_STATE(38)] = 448,
-  [SMALL_STATE(39)] = 456,
-  [SMALL_STATE(40)] = 464,
-  [SMALL_STATE(41)] = 472,
-  [SMALL_STATE(42)] = 480,
-  [SMALL_STATE(43)] = 488,
-  [SMALL_STATE(44)] = 496,
-  [SMALL_STATE(45)] = 504,
-  [SMALL_STATE(46)] = 512,
-  [SMALL_STATE(47)] = 520,
-  [SMALL_STATE(48)] = 528,
-  [SMALL_STATE(49)] = 536,
-  [SMALL_STATE(50)] = 544,
-  [SMALL_STATE(51)] = 552,
-  [SMALL_STATE(52)] = 560,
-  [SMALL_STATE(53)] = 568,
-  [SMALL_STATE(54)] = 576,
-  [SMALL_STATE(55)] = 584,
-  [SMALL_STATE(56)] = 592,
-  [SMALL_STATE(57)] = 600,
-  [SMALL_STATE(58)] = 608,
-  [SMALL_STATE(59)] = 616,
-  [SMALL_STATE(60)] = 624,
+  [SMALL_STATE(31)] = 373,
+  [SMALL_STATE(32)] = 387,
+  [SMALL_STATE(33)] = 401,
+  [SMALL_STATE(34)] = 415,
+  [SMALL_STATE(35)] = 431,
+  [SMALL_STATE(36)] = 443,
+  [SMALL_STATE(37)] = 457,
+  [SMALL_STATE(38)] = 468,
+  [SMALL_STATE(39)] = 479,
+  [SMALL_STATE(40)] = 490,
+  [SMALL_STATE(41)] = 499,
+  [SMALL_STATE(42)] = 510,
+  [SMALL_STATE(43)] = 521,
+  [SMALL_STATE(44)] = 530,
+  [SMALL_STATE(45)] = 538,
+  [SMALL_STATE(46)] = 546,
+  [SMALL_STATE(47)] = 554,
+  [SMALL_STATE(48)] = 562,
+  [SMALL_STATE(49)] = 570,
+  [SMALL_STATE(50)] = 578,
+  [SMALL_STATE(51)] = 586,
+  [SMALL_STATE(52)] = 594,
+  [SMALL_STATE(53)] = 602,
+  [SMALL_STATE(54)] = 610,
+  [SMALL_STATE(55)] = 618,
+  [SMALL_STATE(56)] = 626,
+  [SMALL_STATE(57)] = 634,
+  [SMALL_STATE(58)] = 642,
+  [SMALL_STATE(59)] = 650,
+  [SMALL_STATE(60)] = 658,
+  [SMALL_STATE(61)] = 666,
+  [SMALL_STATE(62)] = 674,
+  [SMALL_STATE(63)] = 682,
+  [SMALL_STATE(64)] = 690,
+  [SMALL_STATE(65)] = 698,
+  [SMALL_STATE(66)] = 706,
+  [SMALL_STATE(67)] = 714,
+  [SMALL_STATE(68)] = 722,
+  [SMALL_STATE(69)] = 730,
+  [SMALL_STATE(70)] = 738,
+  [SMALL_STATE(71)] = 746,
+  [SMALL_STATE(72)] = 754,
+  [SMALL_STATE(73)] = 762,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -1895,100 +2199,115 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 0, 0, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
-  [27] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(8),
-  [30] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(59),
-  [33] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
-  [36] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(13),
-  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
-  [42] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(35),
-  [45] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(38),
-  [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(56),
-  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(39),
-  [54] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [56] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [60] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
-  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
-  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
-  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
-  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
-  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
-  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
-  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
-  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
-  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [83] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [85] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
-  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
-  [91] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
-  [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [99] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
-  [101] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
-  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [105] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
-  [109] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(22),
-  [112] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(22),
-  [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(18),
-  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0), SHIFT_REPEAT(34),
-  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0),
-  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [133] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(29),
-  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [138] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 2, 0, 0),
-  [144] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 2, 0, 0),
-  [146] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 3, 0, 4),
-  [148] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
-  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 3, 0, 0),
-  [156] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 3, 0, 0),
-  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 4, 0, 0),
-  [160] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 4, 0, 0),
-  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 5),
-  [168] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [170] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
-  [174] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
-  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [182] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 4, 0, 6),
-  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 7),
-  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_undef_directive, 2, 0, 2),
-  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 9),
-  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 10),
-  [198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
-  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 8),
-  [206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 11),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
+  [35] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(10),
+  [38] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(65),
+  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(24),
+  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
+  [47] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(23),
+  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(38),
+  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(50),
+  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(47),
+  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(67),
+  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elifdef_directive, 2, 0, 7),
+  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elifdef_directive, 3, 0, 7),
+  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
+  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
+  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
+  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
+  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
+  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [78] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [80] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
+  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(24),
+  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
+  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_ifdef_directive_repeat1, 2, 0, 13),
+  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_ifdef_directive_repeat1, 2, 0, 13), SHIFT_REPEAT(54),
+  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
+  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [100] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
+  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
+  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
+  [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
+  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
+  [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [114] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
+  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_ifdef_directive_repeat1, 1, 0, 8),
+  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
+  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
+  [123] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
+  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
+  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [130] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0), SHIFT_REPEAT(40),
+  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0),
+  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [147] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(34),
+  [150] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [152] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [154] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(23),
+  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 4, 0, 0),
+  [161] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 4, 0, 0),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 2, 0, 0),
+  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 2, 0, 0),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 3, 0, 0),
+  [173] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 3, 0, 0),
+  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 3, 0, 4),
+  [177] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
+  [179] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
+  [181] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 5),
+  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [187] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [189] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
+  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 9),
+  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [197] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 4, 0, 6),
+  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 7),
+  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
+  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 10),
+  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 11),
+  [211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_undef_directive, 2, 0, 2),
+  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 12),
+  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [219] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
+  [227] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [229] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 14),
+  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 15),
+  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 16),
+  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 7, 0, 17),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,15 +5,15 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 81
-#define LARGE_STATE_COUNT 13
-#define SYMBOL_COUNT 57
+#define STATE_COUNT 91
+#define LARGE_STATE_COUNT 15
+#define SYMBOL_COUNT 59
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 31
+#define TOKEN_COUNT 32
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 7
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
-#define PRODUCTION_ID_COUNT 18
+#define PRODUCTION_ID_COUNT 20
 
 enum ts_symbol_identifiers {
   aux_sym__line_token1 = 1,
@@ -45,34 +45,36 @@ enum ts_symbol_identifiers {
   aux_sym_elifdef_directive_token1 = 27,
   aux_sym_elifdef_directive_token2 = 28,
   aux_sym_else_directive_token1 = 29,
-  sym_identifier = 30,
-  sym_resources = 31,
-  sym__line = 32,
-  sym__statement = 33,
-  sym_resource = 34,
-  sym_components = 35,
-  sym_binding = 36,
-  sym_resource_value = 37,
-  sym_string = 38,
-  sym_include_directive = 39,
-  sym_define_directive = 40,
-  sym_define_function_directive = 41,
-  sym_parameters = 42,
-  sym_undef_directive = 43,
-  sym_if_directive = 44,
-  sym_ifdef_directive = 45,
-  sym__if_directive_body = 46,
-  sym_elif_directive = 47,
-  sym_elifdef_directive = 48,
-  sym_else_directive = 49,
-  aux_sym_resources_repeat1 = 50,
-  aux_sym_resource_repeat1 = 51,
-  aux_sym_components_repeat1 = 52,
-  aux_sym_components_repeat2 = 53,
-  aux_sym_resource_value_repeat1 = 54,
-  aux_sym_parameters_repeat1 = 55,
-  aux_sym__if_directive_body_repeat1 = 56,
-  alias_sym_body = 57,
+  sym_directive = 30,
+  sym_identifier = 31,
+  sym_resources = 32,
+  sym__line = 33,
+  sym__statement = 34,
+  sym_resource = 35,
+  sym_components = 36,
+  sym_binding = 37,
+  sym_resource_value = 38,
+  sym_string = 39,
+  sym_include_directive = 40,
+  sym_define_directive = 41,
+  sym_define_function_directive = 42,
+  sym_parameters = 43,
+  sym_undef_directive = 44,
+  sym_if_directive = 45,
+  sym_ifdef_directive = 46,
+  sym__if_directive_body = 47,
+  sym_elif_directive = 48,
+  sym_elifdef_directive = 49,
+  sym_else_directive = 50,
+  sym_simple_directive = 51,
+  aux_sym_resources_repeat1 = 52,
+  aux_sym_resource_repeat1 = 53,
+  aux_sym_components_repeat1 = 54,
+  aux_sym_components_repeat2 = 55,
+  aux_sym_resource_value_repeat1 = 56,
+  aux_sym_parameters_repeat1 = 57,
+  aux_sym__if_directive_body_repeat1 = 58,
+  alias_sym_body = 59,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -106,6 +108,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_elifdef_directive_token1] = "#elifdef",
   [aux_sym_elifdef_directive_token2] = "#elifndef",
   [aux_sym_else_directive_token1] = "#else",
+  [sym_directive] = "directive",
   [sym_identifier] = "identifier",
   [sym_resources] = "resources",
   [sym__line] = "_line",
@@ -126,6 +129,7 @@ static const char * const ts_symbol_names[] = {
   [sym_elif_directive] = "elif_directive",
   [sym_elifdef_directive] = "elifdef_directive",
   [sym_else_directive] = "else_directive",
+  [sym_simple_directive] = "simple_directive",
   [aux_sym_resources_repeat1] = "resources_repeat1",
   [aux_sym_resource_repeat1] = "resource_repeat1",
   [aux_sym_components_repeat1] = "components_repeat1",
@@ -167,6 +171,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_elifdef_directive_token1] = aux_sym_elifdef_directive_token1,
   [aux_sym_elifdef_directive_token2] = aux_sym_elifdef_directive_token2,
   [aux_sym_else_directive_token1] = aux_sym_else_directive_token1,
+  [sym_directive] = sym_directive,
   [sym_identifier] = sym_identifier,
   [sym_resources] = sym_resources,
   [sym__line] = sym__line,
@@ -187,6 +192,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_elif_directive] = sym_elif_directive,
   [sym_elifdef_directive] = sym_elifdef_directive,
   [sym_else_directive] = sym_else_directive,
+  [sym_simple_directive] = sym_simple_directive,
   [aux_sym_resources_repeat1] = aux_sym_resources_repeat1,
   [aux_sym_resource_repeat1] = aux_sym_resource_repeat1,
   [aux_sym_components_repeat1] = aux_sym_components_repeat1,
@@ -318,6 +324,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [sym_directive] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_identifier] = {
     .visible = true,
     .named = true,
@@ -398,6 +408,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_simple_directive] = {
+    .visible = true,
+    .named = true,
+  },
   [aux_sym_resources_repeat1] = {
     .visible = false,
     .named = false,
@@ -456,69 +470,76 @@ static const char * const ts_field_names[] = {
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [1] = {.index = 0, .length = 1},
   [2] = {.index = 1, .length = 1},
-  [3] = {.index = 2, .length = 2},
-  [4] = {.index = 4, .length = 2},
-  [5] = {.index = 6, .length = 2},
-  [6] = {.index = 8, .length = 3},
-  [7] = {.index = 11, .length = 3},
-  [8] = {.index = 14, .length = 1},
-  [9] = {.index = 15, .length = 2},
+  [3] = {.index = 2, .length = 1},
+  [4] = {.index = 3, .length = 2},
+  [5] = {.index = 5, .length = 2},
+  [6] = {.index = 7, .length = 2},
+  [7] = {.index = 9, .length = 2},
+  [8] = {.index = 11, .length = 3},
+  [9] = {.index = 14, .length = 3},
   [10] = {.index = 17, .length = 1},
-  [11] = {.index = 18, .length = 1},
-  [12] = {.index = 19, .length = 1},
-  [13] = {.index = 20, .length = 2},
-  [14] = {.index = 22, .length = 2},
-  [15] = {.index = 24, .length = 2},
-  [16] = {.index = 26, .length = 2},
-  [17] = {.index = 28, .length = 3},
+  [11] = {.index = 18, .length = 2},
+  [12] = {.index = 20, .length = 1},
+  [13] = {.index = 21, .length = 1},
+  [14] = {.index = 22, .length = 1},
+  [15] = {.index = 23, .length = 2},
+  [16] = {.index = 25, .length = 2},
+  [17] = {.index = 27, .length = 2},
+  [18] = {.index = 29, .length = 2},
+  [19] = {.index = 31, .length = 3},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
   [0] =
-    {field_file, 1},
+    {field_name, 0},
   [1] =
-    {field_name, 1},
+    {field_file, 1},
   [2] =
     {field_name, 1},
+  [3] =
+    {field_name, 0},
+    {field_value, 1},
+  [5] =
+    {field_name, 1},
     {field_value, 2},
-  [4] =
+  [7] =
     {field_name, 1},
     {field_parameters, 2},
-  [6] =
+  [9] =
     {field_name, 0},
     {field_value, 2},
-  [8] =
+  [11] =
     {field_name, 1},
     {field_parameters, 2},
     {field_value, 3},
-  [11] =
+  [14] =
     {field_alternative, 3, .inherited = true},
     {field_condition, 1},
     {field_consequence, 3, .inherited = true},
-  [14] =
+  [17] =
     {field_alternative, 0},
-  [15] =
+  [18] =
     {field_name, 0},
     {field_value, 3},
-  [17] =
-    {field_condition, 1},
-  [18] =
-    {field_consequence, 0},
-  [19] =
-    {field_alternative, 0, .inherited = true},
   [20] =
-    {field_alternative, 0, .inherited = true},
-    {field_alternative, 1, .inherited = true},
+    {field_condition, 1},
+  [21] =
+    {field_consequence, 0},
   [22] =
+    {field_alternative, 0, .inherited = true},
+  [23] =
+    {field_alternative, 0, .inherited = true},
+    {field_alternative, 1, .inherited = true},
+  [25] =
     {field_alternative, 1},
     {field_consequence, 0},
-  [24] =
+  [27] =
     {field_alternative, 1, .inherited = true},
     {field_consequence, 0},
-  [26] =
+  [29] =
     {field_alternative, 0, .inherited = true},
     {field_alternative, 1},
-  [28] =
+  [31] =
     {field_alternative, 1, .inherited = true},
     {field_alternative, 2},
     {field_consequence, 0},
@@ -526,16 +547,16 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
-  [11] = {
+  [13] = {
     [0] = alias_sym_body,
   },
-  [14] = {
-    [0] = alias_sym_body,
-  },
-  [15] = {
+  [16] = {
     [0] = alias_sym_body,
   },
   [17] = {
+    [0] = alias_sym_body,
+  },
+  [19] = {
     [0] = alias_sym_body,
   },
 };
@@ -558,17 +579,17 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [7] = 7,
   [8] = 8,
   [9] = 9,
-  [10] = 10,
+  [10] = 9,
   [11] = 11,
   [12] = 12,
-  [13] = 13,
+  [13] = 9,
   [14] = 14,
   [15] = 15,
   [16] = 16,
-  [17] = 17,
-  [18] = 18,
-  [19] = 19,
-  [20] = 20,
+  [17] = 15,
+  [18] = 16,
+  [19] = 16,
+  [20] = 15,
   [21] = 21,
   [22] = 22,
   [23] = 23,
@@ -629,6 +650,16 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [78] = 78,
   [79] = 79,
   [80] = 80,
+  [81] = 81,
+  [82] = 82,
+  [83] = 83,
+  [84] = 84,
+  [85] = 85,
+  [86] = 86,
+  [87] = 87,
+  [88] = 82,
+  [89] = 82,
+  [90] = 90,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -636,572 +667,910 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(49);
+      if (eof) ADVANCE(34);
       ADVANCE_MAP(
-        '\n', 50,
-        '!', 53,
-        '(', 88,
-        ')', 91,
-        '*', 72,
-        ',', 90,
-        '.', 71,
-        '/', 98,
-        ':', 68,
-        '?', 74,
-        '\t', 69,
-        ' ', 69,
+        '\n', 35,
+        '!', 38,
+        '(', 73,
+        ')', 76,
+        '*', 57,
+        ',', 75,
+        '.', 56,
+        '/', 83,
+        ':', 53,
+        '?', 59,
+        '\t', 54,
+        ' ', 54,
       );
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(100);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(85);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(50);
-      if (lookahead == '(') ADVANCE(88);
-      if (lookahead == '/') ADVANCE(98);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(69);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(100);
+      ADVANCE_MAP(
+        '\n', 35,
+        '!', 39,
+        '#', 14,
+        '*', 57,
+        '.', 56,
+        '/', 8,
+        '?', 59,
+        '\t', 54,
+        ' ', 54,
+      );
+      if (('-' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(50);
-      if (lookahead == '/') ADVANCE(98);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(69);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(100);
+      ADVANCE_MAP(
+        '\n', 35,
+        '!', 39,
+        '#', 15,
+        '*', 57,
+        '.', 56,
+        '/', 8,
+        '?', 59,
+        '\t', 54,
+        ' ', 54,
+      );
+      if (('-' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
       END_STATE();
     case 3:
-      if (lookahead == '\n') ADVANCE(50);
-      if (lookahead == '/') ADVANCE(77);
-      if (lookahead == '\\') ADVANCE(78);
+      if (lookahead == '\n') ADVANCE(35);
+      if (lookahead == '(') ADVANCE(73);
+      if (lookahead == '/') ADVANCE(83);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(69);
-      if (lookahead != 0) ADVANCE(76);
+          lookahead == ' ') ADVANCE(54);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(85);
       END_STATE();
     case 4:
-      if (lookahead == '\r') ADVANCE(65);
-      if (lookahead == '\\') ADVANCE(57);
-      if (lookahead != 0) ADVANCE(64);
+      if (lookahead == '\n') ADVANCE(35);
+      if (lookahead == '/') ADVANCE(83);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(54);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(85);
       END_STATE();
     case 5:
-      if (lookahead == ')') ADVANCE(91);
-      if (lookahead == '.') ADVANCE(11);
-      if (lookahead == '/') ADVANCE(6);
+      if (lookahead == '\n') ADVANCE(35);
+      if (lookahead == '/') ADVANCE(62);
+      if (lookahead == '\\') ADVANCE(63);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(69);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(111);
+          lookahead == ' ') ADVANCE(54);
+      if (lookahead != 0) ADVANCE(61);
       END_STATE();
     case 6:
-      if (lookahead == '*') ADVANCE(9);
-      if (lookahead == '/') ADVANCE(64);
+      if (lookahead == '\r') ADVANCE(50);
+      if (lookahead == '\\') ADVANCE(42);
+      if (lookahead != 0) ADVANCE(49);
       END_STATE();
     case 7:
-      if (lookahead == '*') ADVANCE(7);
-      if (lookahead == '/') ADVANCE(55);
-      if (lookahead != 0) ADVANCE(9);
+      if (lookahead == '#') ADVANCE(19);
+      if (lookahead == ')') ADVANCE(76);
+      if (lookahead == '.') ADVANCE(13);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(54);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 8:
-      if (lookahead == '*') ADVANCE(7);
-      if (lookahead != 0) ADVANCE(93);
+      if (lookahead == '*') ADVANCE(11);
+      if (lookahead == '/') ADVANCE(49);
       END_STATE();
     case 9:
-      if (lookahead == '*') ADVANCE(7);
-      if (lookahead != 0) ADVANCE(9);
+      if (lookahead == '*') ADVANCE(9);
+      if (lookahead == '/') ADVANCE(40);
+      if (lookahead != 0) ADVANCE(11);
       END_STATE();
     case 10:
-      if (lookahead == '.') ADVANCE(89);
+      if (lookahead == '*') ADVANCE(9);
+      if (lookahead != 0) ADVANCE(78);
       END_STATE();
     case 11:
-      if (lookahead == '.') ADVANCE(10);
+      if (lookahead == '*') ADVANCE(9);
+      if (lookahead != 0) ADVANCE(11);
       END_STATE();
     case 12:
-      if (lookahead == 'c') ADVANCE(41);
+      if (lookahead == '.') ADVANCE(74);
       END_STATE();
     case 13:
-      if (lookahead == 'd') ADVANCE(19);
-      if (lookahead == 'e') ADVANCE(40);
-      if (lookahead == 'i') ADVANCE(28);
-      if (lookahead == 'u') ADVANCE(42);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(13);
+      if (lookahead == '.') ADVANCE(12);
       END_STATE();
     case 14:
-      if (lookahead == 'd') ADVANCE(39);
+      if (lookahead == 'd') ADVANCE(107);
+      if (lookahead == 'e') ADVANCE(129);
+      if (lookahead == 'i') ADVANCE(116);
+      if (lookahead == 'u') ADVANCE(130);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(14);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
     case 15:
-      if (lookahead == 'd') ADVANCE(22);
+      if (lookahead == 'd') ADVANCE(107);
+      if (lookahead == 'e') ADVANCE(132);
+      if (lookahead == 'i') ADVANCE(116);
+      if (lookahead == 'u') ADVANCE(130);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(15);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
     case 16:
-      if (lookahead == 'd') ADVANCE(24);
+      if (lookahead == 'd') ADVANCE(107);
+      if (lookahead == 'i') ADVANCE(116);
+      if (lookahead == 'u') ADVANCE(130);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(16);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
     case 17:
-      if (lookahead == 'd') ADVANCE(25);
+      if (lookahead == 'd') ADVANCE(28);
       END_STATE();
     case 18:
-      if (lookahead == 'd') ADVANCE(27);
+      if (lookahead == 'd') ADVANCE(22);
       END_STATE();
     case 19:
       if (lookahead == 'e') ADVANCE(29);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(19);
       END_STATE();
     case 20:
-      if (lookahead == 'e') ADVANCE(110);
+      if (lookahead == 'e') ADVANCE(99);
       END_STATE();
     case 21:
-      if (lookahead == 'e') ADVANCE(87);
+      if (lookahead == 'e') ADVANCE(25);
       END_STATE();
     case 22:
-      if (lookahead == 'e') ADVANCE(86);
+      if (lookahead == 'e') ADVANCE(26);
       END_STATE();
     case 23:
-      if (lookahead == 'e') ADVANCE(32);
+      if (lookahead == 'f') ADVANCE(93);
       END_STATE();
     case 24:
-      if (lookahead == 'e') ADVANCE(33);
+      if (lookahead == 'f') ADVANCE(91);
       END_STATE();
     case 25:
-      if (lookahead == 'e') ADVANCE(34);
+      if (lookahead == 'f') ADVANCE(95);
       END_STATE();
     case 26:
-      if (lookahead == 'e') ADVANCE(35);
+      if (lookahead == 'f') ADVANCE(97);
       END_STATE();
     case 27:
-      if (lookahead == 'e') ADVANCE(36);
-      END_STATE();
-    case 28:
-      if (lookahead == 'f') ADVANCE(103);
-      if (lookahead == 'n') ADVANCE(12);
-      END_STATE();
-    case 29:
-      if (lookahead == 'f') ADVANCE(37);
-      END_STATE();
-    case 30:
-      if (lookahead == 'f') ADVANCE(107);
-      END_STATE();
-    case 31:
-      if (lookahead == 'f') ADVANCE(106);
-      END_STATE();
-    case 32:
-      if (lookahead == 'f') ADVANCE(104);
-      END_STATE();
-    case 33:
-      if (lookahead == 'f') ADVANCE(102);
-      END_STATE();
-    case 34:
-      if (lookahead == 'f') ADVANCE(105);
-      END_STATE();
-    case 35:
-      if (lookahead == 'f') ADVANCE(108);
-      END_STATE();
-    case 36:
-      if (lookahead == 'f') ADVANCE(109);
-      END_STATE();
-    case 37:
-      if (lookahead == 'i') ADVANCE(43);
-      END_STATE();
-    case 38:
-      if (lookahead == 'i') ADVANCE(30);
+      if (lookahead == 'i') ADVANCE(23);
       if (lookahead == 's') ADVANCE(20);
       END_STATE();
-    case 39:
-      if (lookahead == 'i') ADVANCE(31);
+    case 28:
+      if (lookahead == 'i') ADVANCE(24);
       END_STATE();
-    case 40:
-      if (lookahead == 'l') ADVANCE(38);
-      if (lookahead == 'n') ADVANCE(14);
+    case 29:
+      if (lookahead == 'l') ADVANCE(27);
+      if (lookahead == 'n') ADVANCE(17);
       END_STATE();
-    case 41:
-      if (lookahead == 'l') ADVANCE(44);
+    case 30:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(60);
       END_STATE();
-    case 42:
-      if (lookahead == 'n') ADVANCE(16);
+    case 31:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(30);
       END_STATE();
-    case 43:
-      if (lookahead == 'n') ADVANCE(21);
-      END_STATE();
-    case 44:
-      if (lookahead == 'u') ADVANCE(15);
-      END_STATE();
-    case 45:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(75);
-      END_STATE();
-    case 46:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(45);
-      END_STATE();
-    case 47:
+    case 32:
       if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(100);
+          lookahead != '*') ADVANCE(85);
       END_STATE();
-    case 48:
-      if (eof) ADVANCE(49);
+    case 33:
+      if (eof) ADVANCE(34);
       ADVANCE_MAP(
-        '\n', 50,
-        '!', 54,
-        '"', 79,
-        '#', 13,
-        ')', 91,
-        '*', 72,
-        ',', 90,
-        '.', 71,
-        '/', 6,
-        ':', 68,
-        '?', 74,
-        '\t', 69,
-        ' ', 69,
+        '\n', 35,
+        '!', 39,
+        '"', 64,
+        '#', 16,
+        ')', 76,
+        '*', 57,
+        ',', 75,
+        '.', 56,
+        '/', 8,
+        ':', 53,
+        '?', 59,
+        '\t', 54,
+        ' ', 54,
       );
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
       END_STATE();
-    case 49:
+    case 34:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 50:
+    case 35:
       ACCEPT_TOKEN(aux_sym__line_token1);
       END_STATE();
-    case 51:
+    case 36:
       ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '\r') ADVANCE(53);
-      if (lookahead == '/') ADVANCE(52);
-      if (lookahead == '\\') ADVANCE(51);
+      if (lookahead == '\r') ADVANCE(38);
+      if (lookahead == '/') ADVANCE(37);
+      if (lookahead == '\\') ADVANCE(36);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(53);
+          lookahead != '\n') ADVANCE(38);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '*') ADVANCE(39);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(38);
+      END_STATE();
+    case 38:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '/') ADVANCE(37);
+      if (lookahead == '\\') ADVANCE(36);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(38);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(39);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\n') ADVANCE(49);
+      if (lookahead == '/') ADVANCE(46);
+      if (lookahead == '\\') ADVANCE(82);
+      if (lookahead != 0) ADVANCE(47);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\r') ADVANCE(50);
+      if (lookahead == '\\') ADVANCE(42);
+      if (lookahead != 0) ADVANCE(49);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\r') ADVANCE(48);
+      if (lookahead == '/') ADVANCE(46);
+      if (lookahead == '\\') ADVANCE(43);
+      if (lookahead != 0) ADVANCE(47);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\r') ADVANCE(51);
+      if (lookahead == '\\') ADVANCE(44);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(49);
+      if (lookahead != 0) ADVANCE(45);
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '"') ADVANCE(49);
+      if (lookahead == '\\') ADVANCE(65);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(45);
+      END_STATE();
+    case 46:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '*') ADVANCE(49);
+      if (lookahead == '\\') ADVANCE(79);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(47);
+      END_STATE();
+    case 47:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '/') ADVANCE(46);
+      if (lookahead == '\\') ADVANCE(82);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(47);
+      END_STATE();
+    case 48:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '/') ADVANCE(46);
+      if (lookahead == '\\') ADVANCE(82);
+      if (lookahead != 0) ADVANCE(47);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(6);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(49);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(6);
+      if (lookahead != 0) ADVANCE(49);
+      END_STATE();
+    case 51:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(65);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(49);
+      if (lookahead != 0) ADVANCE(45);
       END_STATE();
     case 52:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '*') ADVANCE(54);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(53);
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(70);
       END_STATE();
     case 53:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '/') ADVANCE(52);
-      if (lookahead == '\\') ADVANCE(51);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(53);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(54);
-      END_STATE();
-    case 55:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      END_STATE();
-    case 56:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\n') ADVANCE(64);
-      if (lookahead == '/') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(97);
-      if (lookahead != 0) ADVANCE(62);
-      END_STATE();
-    case 57:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(65);
-      if (lookahead == '\\') ADVANCE(57);
-      if (lookahead != 0) ADVANCE(64);
-      END_STATE();
-    case 58:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(63);
-      if (lookahead == '/') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(58);
-      if (lookahead != 0) ADVANCE(62);
-      END_STATE();
-    case 59:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(66);
-      if (lookahead == '\\') ADVANCE(59);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(64);
-      if (lookahead != 0) ADVANCE(60);
-      END_STATE();
-    case 60:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '"') ADVANCE(64);
-      if (lookahead == '\\') ADVANCE(80);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(60);
-      END_STATE();
-    case 61:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '*') ADVANCE(64);
-      if (lookahead == '\\') ADVANCE(94);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(62);
-      END_STATE();
-    case 62:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '/') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(97);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(62);
-      END_STATE();
-    case 63:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '/') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(97);
-      if (lookahead != 0) ADVANCE(62);
-      END_STATE();
-    case 64:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(4);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(64);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(4);
-      if (lookahead != 0) ADVANCE(64);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(80);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(64);
-      if (lookahead != 0) ADVANCE(60);
-      END_STATE();
-    case 67:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(85);
-      END_STATE();
-    case 68:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 69:
+    case 54:
       ACCEPT_TOKEN(aux_sym_resource_token1);
       END_STATE();
-    case 70:
+    case 55:
       ACCEPT_TOKEN(aux_sym_resource_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(85);
+          lookahead != '"') ADVANCE(70);
       END_STATE();
-    case 71:
+    case 56:
       ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
-    case 72:
+    case 57:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 73:
+    case 58:
       ACCEPT_TOKEN(sym_component);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
       END_STATE();
-    case 74:
+    case 59:
       ACCEPT_TOKEN(sym_any_component);
       END_STATE();
-    case 75:
+    case 60:
       ACCEPT_TOKEN(sym_escape_sequence);
       END_STATE();
-    case 76:
+    case 61:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       END_STATE();
-    case 77:
+    case 62:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
-      if (lookahead == '*') ADVANCE(9);
-      if (lookahead == '/') ADVANCE(64);
+      if (lookahead == '*') ADVANCE(11);
+      if (lookahead == '/') ADVANCE(49);
       END_STATE();
-    case 78:
+    case 63:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == ' ' ||
           lookahead == '\\' ||
-          lookahead == 'n') ADVANCE(75);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(46);
+          lookahead == 'n') ADVANCE(60);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(31);
       END_STATE();
-    case 79:
+    case 64:
       ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
-    case 80:
+    case 65:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '\r') ADVANCE(66);
-      if (lookahead == '\\') ADVANCE(59);
+      if (lookahead == '\r') ADVANCE(51);
+      if (lookahead == '\\') ADVANCE(44);
       if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(64);
-      if (lookahead != 0) ADVANCE(60);
+          lookahead == '"') ADVANCE(49);
+      if (lookahead != 0) ADVANCE(45);
       END_STATE();
-    case 81:
+    case 66:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(83);
-      if (lookahead == '/') ADVANCE(60);
+      if (lookahead == '*') ADVANCE(68);
+      if (lookahead == '/') ADVANCE(45);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(85);
+          lookahead != '"') ADVANCE(70);
       END_STATE();
-    case 82:
+    case 67:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(82);
-      if (lookahead == '/') ADVANCE(67);
+      if (lookahead == '*') ADVANCE(67);
+      if (lookahead == '/') ADVANCE(52);
       if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(9);
-      if (lookahead != 0) ADVANCE(83);
+          lookahead == '"') ADVANCE(11);
+      if (lookahead != 0) ADVANCE(68);
       END_STATE();
-    case 83:
+    case 68:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(82);
+      if (lookahead == '*') ADVANCE(67);
       if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(9);
-      if (lookahead != 0) ADVANCE(83);
+          lookahead == '"') ADVANCE(11);
+      if (lookahead != 0) ADVANCE(68);
       END_STATE();
-    case 84:
+    case 69:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '/') ADVANCE(81);
+      if (lookahead == '/') ADVANCE(66);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(70);
+          lookahead == ' ') ADVANCE(55);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(85);
+          lookahead != '"') ADVANCE(70);
       END_STATE();
-    case 85:
+    case 70:
       ACCEPT_TOKEN(aux_sym_string_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(85);
+          lookahead != '"') ADVANCE(70);
       END_STATE();
-    case 86:
+    case 71:
       ACCEPT_TOKEN(aux_sym_include_directive_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
-    case 87:
+    case 72:
       ACCEPT_TOKEN(aux_sym_define_directive_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
-    case 88:
+    case 73:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
-    case 89:
+    case 74:
       ACCEPT_TOKEN(anon_sym_DOT_DOT_DOT);
       END_STATE();
-    case 90:
+    case 75:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 91:
+    case 76:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 92:
+    case 77:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(9);
-      if (lookahead == '*') ADVANCE(92);
-      if (lookahead == '/') ADVANCE(55);
-      if (lookahead == '\\') ADVANCE(96);
-      if (lookahead != 0) ADVANCE(93);
+      if (lookahead == '\n') ADVANCE(11);
+      if (lookahead == '*') ADVANCE(77);
+      if (lookahead == '/') ADVANCE(40);
+      if (lookahead == '\\') ADVANCE(81);
+      if (lookahead != 0) ADVANCE(78);
       END_STATE();
-    case 93:
+    case 78:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(9);
-      if (lookahead == '*') ADVANCE(92);
-      if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '\\') ADVANCE(96);
-      if (lookahead != 0) ADVANCE(93);
+      if (lookahead == '\n') ADVANCE(11);
+      if (lookahead == '*') ADVANCE(77);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == '\\') ADVANCE(81);
+      if (lookahead != 0) ADVANCE(78);
       END_STATE();
-    case 94:
+    case 79:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(64);
-      if (lookahead == '\r') ADVANCE(56);
-      if (lookahead == '/') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(58);
-      if (lookahead != 0) ADVANCE(62);
+      if (lookahead == '\n') ADVANCE(49);
+      if (lookahead == '\r') ADVANCE(41);
+      if (lookahead == '/') ADVANCE(46);
+      if (lookahead == '\\') ADVANCE(43);
+      if (lookahead != 0) ADVANCE(47);
       END_STATE();
-    case 95:
+    case 80:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(101);
-      if (lookahead == '/') ADVANCE(47);
-      if (lookahead == '\\') ADVANCE(95);
-      if (lookahead != 0) ADVANCE(100);
+      if (lookahead == '\r') ADVANCE(86);
+      if (lookahead == '/') ADVANCE(32);
+      if (lookahead == '\\') ADVANCE(80);
+      if (lookahead != 0) ADVANCE(85);
       END_STATE();
-    case 96:
+    case 81:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(99);
-      if (lookahead == '*') ADVANCE(92);
-      if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '\\') ADVANCE(96);
-      if (lookahead != 0) ADVANCE(93);
+      if (lookahead == '\r') ADVANCE(84);
+      if (lookahead == '*') ADVANCE(77);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == '\\') ADVANCE(81);
+      if (lookahead != 0) ADVANCE(78);
       END_STATE();
-    case 97:
+    case 82:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(63);
-      if (lookahead == '/') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(58);
-      if (lookahead != 0) ADVANCE(62);
+      if (lookahead == '\r') ADVANCE(48);
+      if (lookahead == '/') ADVANCE(46);
+      if (lookahead == '\\') ADVANCE(43);
+      if (lookahead != 0) ADVANCE(47);
       END_STATE();
-    case 98:
+    case 83:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(93);
-      if (lookahead == '/') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(95);
+      if (lookahead == '*') ADVANCE(78);
+      if (lookahead == '/') ADVANCE(46);
+      if (lookahead == '\\') ADVANCE(80);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(100);
+          lookahead != '\n') ADVANCE(85);
       END_STATE();
-    case 99:
+    case 84:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(92);
-      if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '\\') ADVANCE(96);
-      if (lookahead != 0) ADVANCE(93);
+      if (lookahead == '*') ADVANCE(77);
+      if (lookahead == '/') ADVANCE(10);
+      if (lookahead == '\\') ADVANCE(81);
+      if (lookahead != 0) ADVANCE(78);
       END_STATE();
-    case 100:
+    case 85:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '/') ADVANCE(47);
-      if (lookahead == '\\') ADVANCE(95);
+      if (lookahead == '/') ADVANCE(32);
+      if (lookahead == '\\') ADVANCE(80);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(100);
+          lookahead != '\n') ADVANCE(85);
       END_STATE();
-    case 101:
+    case 86:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '/') ADVANCE(47);
-      if (lookahead == '\\') ADVANCE(95);
-      if (lookahead != 0) ADVANCE(100);
+      if (lookahead == '/') ADVANCE(32);
+      if (lookahead == '\\') ADVANCE(80);
+      if (lookahead != 0) ADVANCE(85);
       END_STATE();
-    case 102:
+    case 87:
       ACCEPT_TOKEN(aux_sym_undef_directive_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
-    case 103:
+    case 88:
       ACCEPT_TOKEN(aux_sym_if_directive_token1);
-      if (lookahead == 'd') ADVANCE(23);
-      if (lookahead == 'n') ADVANCE(17);
+      if (lookahead == 'd') ADVANCE(111);
+      if (lookahead == 'n') ADVANCE(105);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
-    case 104:
+    case 89:
       ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
-    case 105:
+    case 90:
       ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
-    case 106:
+    case 91:
       ACCEPT_TOKEN(aux_sym__if_directive_body_token1);
       END_STATE();
-    case 107:
+    case 92:
+      ACCEPT_TOKEN(aux_sym__if_directive_body_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 93:
       ACCEPT_TOKEN(aux_sym_elif_directive_token1);
-      if (lookahead == 'd') ADVANCE(26);
+      if (lookahead == 'd') ADVANCE(21);
       if (lookahead == 'n') ADVANCE(18);
       END_STATE();
-    case 108:
+    case 94:
+      ACCEPT_TOKEN(aux_sym_elif_directive_token1);
+      if (lookahead == 'd') ADVANCE(114);
+      if (lookahead == 'n') ADVANCE(106);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 95:
       ACCEPT_TOKEN(aux_sym_elifdef_directive_token1);
       END_STATE();
-    case 109:
+    case 96:
+      ACCEPT_TOKEN(aux_sym_elifdef_directive_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 97:
       ACCEPT_TOKEN(aux_sym_elifdef_directive_token2);
       END_STATE();
-    case 110:
+    case 98:
+      ACCEPT_TOKEN(aux_sym_elifdef_directive_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 99:
       ACCEPT_TOKEN(aux_sym_else_directive_token1);
       END_STATE();
+    case 100:
+      ACCEPT_TOKEN(aux_sym_else_directive_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'c') ADVANCE(128);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 102:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'd') ADVANCE(127);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 103:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'd') ADVANCE(109);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 104:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'd') ADVANCE(112);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 105:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'd') ADVANCE(113);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'd') ADVANCE(115);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'e') ADVANCE(117);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 108:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'e') ADVANCE(72);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 109:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'e') ADVANCE(71);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 110:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'e') ADVANCE(100);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
     case 111:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'e') ADVANCE(118);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 112:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'e') ADVANCE(119);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 113:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'e') ADVANCE(120);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 114:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'e') ADVANCE(123);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'e') ADVANCE(124);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 116:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'f') ADVANCE(88);
+      if (lookahead == 'n') ADVANCE(101);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 117:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'f') ADVANCE(125);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 118:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'f') ADVANCE(89);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 119:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'f') ADVANCE(87);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 120:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'f') ADVANCE(90);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 121:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'f') ADVANCE(94);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 122:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'f') ADVANCE(92);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'f') ADVANCE(96);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 124:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'f') ADVANCE(98);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 125:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'i') ADVANCE(131);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'i') ADVANCE(121);
+      if (lookahead == 's') ADVANCE(110);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'i') ADVANCE(122);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'l') ADVANCE(133);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 129:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'l') ADVANCE(126);
+      if (lookahead == 'n') ADVANCE(102);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'n') ADVANCE(104);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'n') ADVANCE(108);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 132:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'n') ADVANCE(102);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'u') ADVANCE(103);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(sym_directive);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      END_STATE();
+    case 135:
       ACCEPT_TOKEN(sym_identifier);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(111);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     default:
       return false;
@@ -1210,86 +1579,96 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 48},
-  [2] = {.lex_state = 48},
-  [3] = {.lex_state = 48},
-  [4] = {.lex_state = 48},
-  [5] = {.lex_state = 48},
-  [6] = {.lex_state = 48},
-  [7] = {.lex_state = 48},
-  [8] = {.lex_state = 48},
-  [9] = {.lex_state = 48},
-  [10] = {.lex_state = 48},
-  [11] = {.lex_state = 48},
-  [12] = {.lex_state = 48},
-  [13] = {.lex_state = 48},
-  [14] = {.lex_state = 48},
-  [15] = {.lex_state = 48},
-  [16] = {.lex_state = 48},
-  [17] = {.lex_state = 48},
-  [18] = {.lex_state = 48},
-  [19] = {.lex_state = 48},
-  [20] = {.lex_state = 48},
-  [21] = {.lex_state = 3},
-  [22] = {.lex_state = 48},
-  [23] = {.lex_state = 3},
-  [24] = {.lex_state = 48},
-  [25] = {.lex_state = 48},
-  [26] = {.lex_state = 48},
-  [27] = {.lex_state = 48},
-  [28] = {.lex_state = 3},
-  [29] = {.lex_state = 1},
-  [30] = {.lex_state = 48},
-  [31] = {.lex_state = 3},
-  [32] = {.lex_state = 48},
-  [33] = {.lex_state = 5},
-  [34] = {.lex_state = 48},
-  [35] = {.lex_state = 48},
-  [36] = {.lex_state = 48},
-  [37] = {.lex_state = 48},
-  [38] = {.lex_state = 48},
-  [39] = {.lex_state = 3},
-  [40] = {.lex_state = 48},
-  [41] = {.lex_state = 48},
-  [42] = {.lex_state = 2},
-  [43] = {.lex_state = 5},
-  [44] = {.lex_state = 2},
-  [45] = {.lex_state = 2},
-  [46] = {.lex_state = 2},
-  [47] = {.lex_state = 84},
-  [48] = {.lex_state = 0},
-  [49] = {.lex_state = 48},
-  [50] = {.lex_state = 48},
-  [51] = {.lex_state = 5},
-  [52] = {.lex_state = 0},
-  [53] = {.lex_state = 0},
-  [54] = {.lex_state = 5},
-  [55] = {.lex_state = 2},
+  [1] = {.lex_state = 33},
+  [2] = {.lex_state = 1},
+  [3] = {.lex_state = 1},
+  [4] = {.lex_state = 1},
+  [5] = {.lex_state = 1},
+  [6] = {.lex_state = 1},
+  [7] = {.lex_state = 1},
+  [8] = {.lex_state = 1},
+  [9] = {.lex_state = 1},
+  [10] = {.lex_state = 2},
+  [11] = {.lex_state = 33},
+  [12] = {.lex_state = 2},
+  [13] = {.lex_state = 33},
+  [14] = {.lex_state = 2},
+  [15] = {.lex_state = 1},
+  [16] = {.lex_state = 1},
+  [17] = {.lex_state = 33},
+  [18] = {.lex_state = 33},
+  [19] = {.lex_state = 2},
+  [20] = {.lex_state = 2},
+  [21] = {.lex_state = 7},
+  [22] = {.lex_state = 7},
+  [23] = {.lex_state = 7},
+  [24] = {.lex_state = 33},
+  [25] = {.lex_state = 33},
+  [26] = {.lex_state = 33},
+  [27] = {.lex_state = 33},
+  [28] = {.lex_state = 5},
+  [29] = {.lex_state = 33},
+  [30] = {.lex_state = 5},
+  [31] = {.lex_state = 33},
+  [32] = {.lex_state = 7},
+  [33] = {.lex_state = 33},
+  [34] = {.lex_state = 3},
+  [35] = {.lex_state = 5},
+  [36] = {.lex_state = 5},
+  [37] = {.lex_state = 33},
+  [38] = {.lex_state = 33},
+  [39] = {.lex_state = 5},
+  [40] = {.lex_state = 33},
+  [41] = {.lex_state = 33},
+  [42] = {.lex_state = 33},
+  [43] = {.lex_state = 33},
+  [44] = {.lex_state = 7},
+  [45] = {.lex_state = 33},
+  [46] = {.lex_state = 4},
+  [47] = {.lex_state = 4},
+  [48] = {.lex_state = 33},
+  [49] = {.lex_state = 7},
+  [50] = {.lex_state = 4},
+  [51] = {.lex_state = 4},
+  [52] = {.lex_state = 33},
+  [53] = {.lex_state = 4},
+  [54] = {.lex_state = 1},
+  [55] = {.lex_state = 0},
   [56] = {.lex_state = 0},
-  [57] = {.lex_state = 2},
-  [58] = {.lex_state = 5},
-  [59] = {.lex_state = 48},
-  [60] = {.lex_state = 0},
+  [57] = {.lex_state = 0},
+  [58] = {.lex_state = 0},
+  [59] = {.lex_state = 33},
+  [60] = {.lex_state = 1},
   [61] = {.lex_state = 0},
-  [62] = {.lex_state = 0},
+  [62] = {.lex_state = 7},
   [63] = {.lex_state = 0},
-  [64] = {.lex_state = 48},
-  [65] = {.lex_state = 5},
+  [64] = {.lex_state = 0},
+  [65] = {.lex_state = 0},
   [66] = {.lex_state = 0},
-  [67] = {.lex_state = 48},
+  [67] = {.lex_state = 0},
   [68] = {.lex_state = 0},
-  [69] = {.lex_state = 0},
-  [70] = {.lex_state = 0},
-  [71] = {.lex_state = 0},
-  [72] = {.lex_state = 0},
+  [69] = {.lex_state = 1},
+  [70] = {.lex_state = 7},
+  [71] = {.lex_state = 7},
+  [72] = {.lex_state = 69},
   [73] = {.lex_state = 0},
   [74] = {.lex_state = 0},
-  [75] = {.lex_state = 0},
-  [76] = {.lex_state = 0},
-  [77] = {.lex_state = 48},
+  [75] = {.lex_state = 4},
+  [76] = {.lex_state = 7},
+  [77] = {.lex_state = 0},
   [78] = {.lex_state = 0},
-  [79] = {.lex_state = 0},
+  [79] = {.lex_state = 1},
   [80] = {.lex_state = 0},
+  [81] = {.lex_state = 0},
+  [82] = {.lex_state = 0},
+  [83] = {.lex_state = 0},
+  [84] = {.lex_state = 0},
+  [85] = {.lex_state = 0},
+  [86] = {.lex_state = 4},
+  [87] = {.lex_state = 33},
+  [88] = {.lex_state = 0},
+  [89] = {.lex_state = 0},
+  [90] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1310,21 +1689,22 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_expansion] = ACTIONS(1),
   },
   [1] = {
-    [sym_resources] = STATE(69),
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [aux_sym_resources_repeat1] = STATE(10),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
+    [sym_resources] = STATE(83),
+    [sym__line] = STATE(18),
+    [sym__statement] = STATE(82),
+    [sym_resource] = STATE(82),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(82),
+    [sym_define_directive] = STATE(82),
+    [sym_define_function_directive] = STATE(82),
+    [sym_undef_directive] = STATE(82),
+    [sym_if_directive] = STATE(82),
+    [sym_ifdef_directive] = STATE(82),
+    [sym_simple_directive] = STATE(82),
+    [aux_sym_resources_repeat1] = STATE(11),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
     [ts_builtin_sym_end] = ACTIONS(5),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
@@ -1340,29 +1720,31 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_if_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token1] = ACTIONS(25),
     [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [sym_directive] = ACTIONS(27),
   },
   [2] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [sym__if_directive_body] = STATE(63),
-    [sym_elif_directive] = STATE(26),
-    [sym_elifdef_directive] = STATE(26),
-    [sym_else_directive] = STATE(49),
+    [sym__line] = STATE(16),
+    [sym__statement] = STATE(88),
+    [sym_resource] = STATE(88),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(88),
+    [sym_define_directive] = STATE(88),
+    [sym_define_function_directive] = STATE(88),
+    [sym_undef_directive] = STATE(88),
+    [sym_if_directive] = STATE(88),
+    [sym_ifdef_directive] = STATE(88),
+    [sym__if_directive_body] = STATE(58),
+    [sym_elif_directive] = STATE(32),
+    [sym_elifdef_directive] = STATE(32),
+    [sym_else_directive] = STATE(60),
+    [sym_simple_directive] = STATE(88),
     [aux_sym_resources_repeat1] = STATE(4),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [aux_sym__if_directive_body_repeat1] = STATE(16),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__if_directive_body_repeat1] = STATE(22),
+    [aux_sym__line_token1] = ACTIONS(29),
+    [sym_comment] = ACTIONS(31),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
     [anon_sym_DOT] = ACTIONS(11),
@@ -1375,34 +1757,36 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_if_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token1] = ACTIONS(25),
     [aux_sym_ifdef_directive_token2] = ACTIONS(25),
-    [aux_sym__if_directive_body_token1] = ACTIONS(27),
-    [aux_sym_elif_directive_token1] = ACTIONS(29),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(31),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(31),
-    [aux_sym_else_directive_token1] = ACTIONS(33),
+    [aux_sym__if_directive_body_token1] = ACTIONS(33),
+    [aux_sym_elif_directive_token1] = ACTIONS(35),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(37),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(37),
+    [aux_sym_else_directive_token1] = ACTIONS(39),
+    [sym_directive] = ACTIONS(27),
   },
   [3] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [sym__if_directive_body] = STATE(52),
-    [sym_elif_directive] = STATE(26),
-    [sym_elifdef_directive] = STATE(26),
-    [sym_else_directive] = STATE(49),
+    [sym__line] = STATE(16),
+    [sym__statement] = STATE(88),
+    [sym_resource] = STATE(88),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(88),
+    [sym_define_directive] = STATE(88),
+    [sym_define_function_directive] = STATE(88),
+    [sym_undef_directive] = STATE(88),
+    [sym_if_directive] = STATE(88),
+    [sym_ifdef_directive] = STATE(88),
+    [sym__if_directive_body] = STATE(84),
+    [sym_elif_directive] = STATE(32),
+    [sym_elifdef_directive] = STATE(32),
+    [sym_else_directive] = STATE(60),
+    [sym_simple_directive] = STATE(88),
     [aux_sym_resources_repeat1] = STATE(4),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [aux_sym__if_directive_body_repeat1] = STATE(16),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__if_directive_body_repeat1] = STATE(22),
+    [aux_sym__line_token1] = ACTIONS(29),
+    [sym_comment] = ACTIONS(31),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
     [anon_sym_DOT] = ACTIONS(11),
@@ -1415,33 +1799,35 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_if_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token1] = ACTIONS(25),
     [aux_sym_ifdef_directive_token2] = ACTIONS(25),
-    [aux_sym__if_directive_body_token1] = ACTIONS(35),
-    [aux_sym_elif_directive_token1] = ACTIONS(29),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(31),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(31),
-    [aux_sym_else_directive_token1] = ACTIONS(33),
+    [aux_sym__if_directive_body_token1] = ACTIONS(41),
+    [aux_sym_elif_directive_token1] = ACTIONS(35),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(37),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(37),
+    [aux_sym_else_directive_token1] = ACTIONS(39),
+    [sym_directive] = ACTIONS(27),
   },
   [4] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [sym_elif_directive] = STATE(26),
-    [sym_elifdef_directive] = STATE(26),
-    [sym_else_directive] = STATE(64),
-    [aux_sym_resources_repeat1] = STATE(5),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [aux_sym__if_directive_body_repeat1] = STATE(15),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [sym__line] = STATE(16),
+    [sym__statement] = STATE(88),
+    [sym_resource] = STATE(88),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(88),
+    [sym_define_directive] = STATE(88),
+    [sym_define_function_directive] = STATE(88),
+    [sym_undef_directive] = STATE(88),
+    [sym_if_directive] = STATE(88),
+    [sym_ifdef_directive] = STATE(88),
+    [sym_elif_directive] = STATE(32),
+    [sym_elifdef_directive] = STATE(32),
+    [sym_else_directive] = STATE(54),
+    [sym_simple_directive] = STATE(88),
+    [aux_sym_resources_repeat1] = STATE(9),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__if_directive_body_repeat1] = STATE(21),
+    [aux_sym__line_token1] = ACTIONS(29),
+    [sym_comment] = ACTIONS(31),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
     [anon_sym_DOT] = ACTIONS(11),
@@ -1454,65 +1840,68 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_if_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token1] = ACTIONS(25),
     [aux_sym_ifdef_directive_token2] = ACTIONS(25),
-    [aux_sym__if_directive_body_token1] = ACTIONS(37),
-    [aux_sym_elif_directive_token1] = ACTIONS(29),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(31),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(31),
-    [aux_sym_else_directive_token1] = ACTIONS(33),
+    [aux_sym__if_directive_body_token1] = ACTIONS(43),
+    [aux_sym_elif_directive_token1] = ACTIONS(35),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(37),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(37),
+    [aux_sym_else_directive_token1] = ACTIONS(39),
+    [sym_directive] = ACTIONS(27),
   },
   [5] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [aux_sym_resources_repeat1] = STATE(5),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [ts_builtin_sym_end] = ACTIONS(39),
-    [aux_sym__line_token1] = ACTIONS(41),
-    [sym_comment] = ACTIONS(44),
+    [sym__line] = STATE(16),
+    [sym__statement] = STATE(88),
+    [sym_resource] = STATE(88),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(88),
+    [sym_define_directive] = STATE(88),
+    [sym_define_function_directive] = STATE(88),
+    [sym_undef_directive] = STATE(88),
+    [sym_if_directive] = STATE(88),
+    [sym_ifdef_directive] = STATE(88),
+    [sym_simple_directive] = STATE(88),
+    [aux_sym_resources_repeat1] = STATE(8),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__line_token1] = ACTIONS(29),
+    [sym_comment] = ACTIONS(31),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(47),
-    [anon_sym_STAR] = ACTIONS(47),
-    [sym_component] = ACTIONS(50),
-    [sym_any_component] = ACTIONS(53),
-    [aux_sym_include_directive_token1] = ACTIONS(56),
-    [aux_sym_define_directive_token1] = ACTIONS(59),
-    [aux_sym_undef_directive_token1] = ACTIONS(62),
-    [aux_sym_if_directive_token1] = ACTIONS(65),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(68),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(68),
-    [aux_sym__if_directive_body_token1] = ACTIONS(39),
-    [aux_sym_elif_directive_token1] = ACTIONS(71),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(39),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(39),
-    [aux_sym_else_directive_token1] = ACTIONS(39),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(45),
+    [aux_sym_elif_directive_token1] = ACTIONS(45),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(45),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(45),
+    [aux_sym_else_directive_token1] = ACTIONS(45),
+    [sym_directive] = ACTIONS(27),
   },
   [6] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [aux_sym_resources_repeat1] = STATE(8),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [sym__line] = STATE(16),
+    [sym__statement] = STATE(88),
+    [sym_resource] = STATE(88),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(88),
+    [sym_define_directive] = STATE(88),
+    [sym_define_function_directive] = STATE(88),
+    [sym_undef_directive] = STATE(88),
+    [sym_if_directive] = STATE(88),
+    [sym_ifdef_directive] = STATE(88),
+    [sym_simple_directive] = STATE(88),
+    [aux_sym_resources_repeat1] = STATE(7),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__line_token1] = ACTIONS(29),
+    [sym_comment] = ACTIONS(31),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
     [anon_sym_DOT] = ACTIONS(11),
@@ -1525,29 +1914,31 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_if_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token1] = ACTIONS(25),
     [aux_sym_ifdef_directive_token2] = ACTIONS(25),
-    [aux_sym__if_directive_body_token1] = ACTIONS(73),
-    [aux_sym_elif_directive_token1] = ACTIONS(75),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(73),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(73),
-    [aux_sym_else_directive_token1] = ACTIONS(73),
+    [aux_sym__if_directive_body_token1] = ACTIONS(47),
+    [aux_sym_elif_directive_token1] = ACTIONS(47),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(47),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(47),
+    [aux_sym_else_directive_token1] = ACTIONS(47),
+    [sym_directive] = ACTIONS(27),
   },
   [7] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
+    [sym__line] = STATE(16),
+    [sym__statement] = STATE(88),
+    [sym_resource] = STATE(88),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(88),
+    [sym_define_directive] = STATE(88),
+    [sym_define_function_directive] = STATE(88),
+    [sym_undef_directive] = STATE(88),
+    [sym_if_directive] = STATE(88),
+    [sym_ifdef_directive] = STATE(88),
+    [sym_simple_directive] = STATE(88),
     [aux_sym_resources_repeat1] = STATE(9),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__line_token1] = ACTIONS(29),
+    [sym_comment] = ACTIONS(31),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
     [anon_sym_DOT] = ACTIONS(11),
@@ -1560,29 +1951,31 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_if_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token1] = ACTIONS(25),
     [aux_sym_ifdef_directive_token2] = ACTIONS(25),
-    [aux_sym__if_directive_body_token1] = ACTIONS(77),
-    [aux_sym_elif_directive_token1] = ACTIONS(79),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(77),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(77),
-    [aux_sym_else_directive_token1] = ACTIONS(77),
+    [aux_sym__if_directive_body_token1] = ACTIONS(49),
+    [aux_sym_elif_directive_token1] = ACTIONS(49),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(49),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(49),
+    [aux_sym_else_directive_token1] = ACTIONS(49),
+    [sym_directive] = ACTIONS(27),
   },
   [8] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [aux_sym_resources_repeat1] = STATE(5),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [sym__line] = STATE(16),
+    [sym__statement] = STATE(88),
+    [sym_resource] = STATE(88),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(88),
+    [sym_define_directive] = STATE(88),
+    [sym_define_function_directive] = STATE(88),
+    [sym_undef_directive] = STATE(88),
+    [sym_if_directive] = STATE(88),
+    [sym_ifdef_directive] = STATE(88),
+    [sym_simple_directive] = STATE(88),
+    [aux_sym_resources_repeat1] = STATE(9),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__line_token1] = ACTIONS(29),
+    [sym_comment] = ACTIONS(31),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
     [anon_sym_DOT] = ACTIONS(11),
@@ -1595,93 +1988,100 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_if_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token1] = ACTIONS(25),
     [aux_sym_ifdef_directive_token2] = ACTIONS(25),
-    [aux_sym__if_directive_body_token1] = ACTIONS(81),
-    [aux_sym_elif_directive_token1] = ACTIONS(83),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(81),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(81),
-    [aux_sym_else_directive_token1] = ACTIONS(81),
+    [aux_sym__if_directive_body_token1] = ACTIONS(51),
+    [aux_sym_elif_directive_token1] = ACTIONS(51),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(51),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(51),
+    [aux_sym_else_directive_token1] = ACTIONS(51),
+    [sym_directive] = ACTIONS(27),
   },
   [9] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [aux_sym_resources_repeat1] = STATE(5),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [sym__line] = STATE(16),
+    [sym__statement] = STATE(88),
+    [sym_resource] = STATE(88),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(88),
+    [sym_define_directive] = STATE(88),
+    [sym_define_function_directive] = STATE(88),
+    [sym_undef_directive] = STATE(88),
+    [sym_if_directive] = STATE(88),
+    [sym_ifdef_directive] = STATE(88),
+    [sym_simple_directive] = STATE(88),
+    [aux_sym_resources_repeat1] = STATE(9),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__line_token1] = ACTIONS(53),
+    [sym_comment] = ACTIONS(56),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(11),
-    [sym_component] = ACTIONS(13),
-    [sym_any_component] = ACTIONS(15),
-    [aux_sym_include_directive_token1] = ACTIONS(17),
-    [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_if_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
-    [aux_sym__if_directive_body_token1] = ACTIONS(85),
-    [aux_sym_elif_directive_token1] = ACTIONS(87),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(85),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(85),
-    [aux_sym_else_directive_token1] = ACTIONS(85),
+    [anon_sym_DOT] = ACTIONS(59),
+    [anon_sym_STAR] = ACTIONS(59),
+    [sym_component] = ACTIONS(62),
+    [sym_any_component] = ACTIONS(65),
+    [aux_sym_include_directive_token1] = ACTIONS(68),
+    [aux_sym_define_directive_token1] = ACTIONS(71),
+    [aux_sym_undef_directive_token1] = ACTIONS(74),
+    [aux_sym_if_directive_token1] = ACTIONS(77),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(80),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(80),
+    [aux_sym__if_directive_body_token1] = ACTIONS(83),
+    [aux_sym_elif_directive_token1] = ACTIONS(83),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(83),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(83),
+    [aux_sym_else_directive_token1] = ACTIONS(83),
+    [sym_directive] = ACTIONS(85),
   },
   [10] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [aux_sym_resources_repeat1] = STATE(5),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [ts_builtin_sym_end] = ACTIONS(89),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [sym__line] = STATE(19),
+    [sym__statement] = STATE(89),
+    [sym_resource] = STATE(89),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(89),
+    [sym_define_directive] = STATE(89),
+    [sym_define_function_directive] = STATE(89),
+    [sym_undef_directive] = STATE(89),
+    [sym_if_directive] = STATE(89),
+    [sym_ifdef_directive] = STATE(89),
+    [sym_simple_directive] = STATE(89),
+    [aux_sym_resources_repeat1] = STATE(10),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__line_token1] = ACTIONS(88),
+    [sym_comment] = ACTIONS(91),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(11),
-    [sym_component] = ACTIONS(13),
-    [sym_any_component] = ACTIONS(15),
-    [aux_sym_include_directive_token1] = ACTIONS(17),
-    [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_if_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [anon_sym_DOT] = ACTIONS(59),
+    [anon_sym_STAR] = ACTIONS(59),
+    [sym_component] = ACTIONS(62),
+    [sym_any_component] = ACTIONS(65),
+    [aux_sym_include_directive_token1] = ACTIONS(68),
+    [aux_sym_define_directive_token1] = ACTIONS(71),
+    [aux_sym_undef_directive_token1] = ACTIONS(74),
+    [aux_sym_if_directive_token1] = ACTIONS(77),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(80),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(80),
+    [aux_sym__if_directive_body_token1] = ACTIONS(83),
+    [sym_directive] = ACTIONS(85),
   },
   [11] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [aux_sym_resources_repeat1] = STATE(12),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
+    [sym__line] = STATE(18),
+    [sym__statement] = STATE(82),
+    [sym_resource] = STATE(82),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(82),
+    [sym_define_directive] = STATE(82),
+    [sym_define_function_directive] = STATE(82),
+    [sym_undef_directive] = STATE(82),
+    [sym_if_directive] = STATE(82),
+    [sym_ifdef_directive] = STATE(82),
+    [sym_simple_directive] = STATE(82),
+    [aux_sym_resources_repeat1] = STATE(13),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [ts_builtin_sym_end] = ACTIONS(94),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1696,25 +2096,26 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_if_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token1] = ACTIONS(25),
     [aux_sym_ifdef_directive_token2] = ACTIONS(25),
-    [aux_sym__if_directive_body_token1] = ACTIONS(91),
+    [sym_directive] = ACTIONS(27),
   },
   [12] = {
-    [sym__line] = STATE(13),
-    [sym__statement] = STATE(48),
-    [sym_resource] = STATE(48),
-    [sym_components] = STATE(50),
-    [sym_binding] = STATE(18),
-    [sym_include_directive] = STATE(48),
-    [sym_define_directive] = STATE(48),
-    [sym_define_function_directive] = STATE(48),
-    [sym_undef_directive] = STATE(48),
-    [sym_if_directive] = STATE(48),
-    [sym_ifdef_directive] = STATE(48),
-    [aux_sym_resources_repeat1] = STATE(5),
-    [aux_sym_components_repeat1] = STATE(18),
-    [aux_sym_components_repeat2] = STATE(37),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [sym__line] = STATE(19),
+    [sym__statement] = STATE(89),
+    [sym_resource] = STATE(89),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(89),
+    [sym_define_directive] = STATE(89),
+    [sym_define_function_directive] = STATE(89),
+    [sym_undef_directive] = STATE(89),
+    [sym_if_directive] = STATE(89),
+    [sym_ifdef_directive] = STATE(89),
+    [sym_simple_directive] = STATE(89),
+    [aux_sym_resources_repeat1] = STATE(14),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__line_token1] = ACTIONS(96),
+    [sym_comment] = ACTIONS(98),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
     [anon_sym_DOT] = ACTIONS(11),
@@ -1727,7 +2128,74 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_if_directive_token1] = ACTIONS(23),
     [aux_sym_ifdef_directive_token1] = ACTIONS(25),
     [aux_sym_ifdef_directive_token2] = ACTIONS(25),
-    [aux_sym__if_directive_body_token1] = ACTIONS(93),
+    [aux_sym__if_directive_body_token1] = ACTIONS(100),
+    [sym_directive] = ACTIONS(27),
+  },
+  [13] = {
+    [sym__line] = STATE(18),
+    [sym__statement] = STATE(82),
+    [sym_resource] = STATE(82),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(82),
+    [sym_define_directive] = STATE(82),
+    [sym_define_function_directive] = STATE(82),
+    [sym_undef_directive] = STATE(82),
+    [sym_if_directive] = STATE(82),
+    [sym_ifdef_directive] = STATE(82),
+    [sym_simple_directive] = STATE(82),
+    [aux_sym_resources_repeat1] = STATE(13),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [ts_builtin_sym_end] = ACTIONS(102),
+    [aux_sym__line_token1] = ACTIONS(104),
+    [sym_comment] = ACTIONS(107),
+    [sym_preprocessor_comment] = ACTIONS(3),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(59),
+    [anon_sym_STAR] = ACTIONS(59),
+    [sym_component] = ACTIONS(62),
+    [sym_any_component] = ACTIONS(65),
+    [aux_sym_include_directive_token1] = ACTIONS(68),
+    [aux_sym_define_directive_token1] = ACTIONS(71),
+    [aux_sym_undef_directive_token1] = ACTIONS(74),
+    [aux_sym_if_directive_token1] = ACTIONS(77),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(80),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(80),
+    [sym_directive] = ACTIONS(85),
+  },
+  [14] = {
+    [sym__line] = STATE(19),
+    [sym__statement] = STATE(89),
+    [sym_resource] = STATE(89),
+    [sym_components] = STATE(59),
+    [sym_binding] = STATE(24),
+    [sym_include_directive] = STATE(89),
+    [sym_define_directive] = STATE(89),
+    [sym_define_function_directive] = STATE(89),
+    [sym_undef_directive] = STATE(89),
+    [sym_if_directive] = STATE(89),
+    [sym_ifdef_directive] = STATE(89),
+    [sym_simple_directive] = STATE(89),
+    [aux_sym_resources_repeat1] = STATE(10),
+    [aux_sym_components_repeat1] = STATE(24),
+    [aux_sym_components_repeat2] = STATE(38),
+    [aux_sym__line_token1] = ACTIONS(96),
+    [sym_comment] = ACTIONS(98),
+    [sym_preprocessor_comment] = ACTIONS(3),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(110),
+    [sym_directive] = ACTIONS(27),
   },
 };
 
@@ -1736,34 +2204,55 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(97), 2,
-      aux_sym_if_directive_token1,
-      aux_sym_elif_directive_token1,
-    ACTIONS(95), 16,
-      ts_builtin_sym_end,
+    ACTIONS(112), 6,
       aux_sym__line_token1,
       sym_comment,
       anon_sym_DOT,
       anon_sym_STAR,
       sym_component,
       sym_any_component,
+    ACTIONS(114), 12,
       aux_sym_include_directive_token1,
       aux_sym_define_directive_token1,
       aux_sym_undef_directive_token1,
+      aux_sym_if_directive_token1,
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
       aux_sym__if_directive_body_token1,
+      aux_sym_elif_directive_token1,
       aux_sym_elifdef_directive_token1,
       aux_sym_elifdef_directive_token2,
       aux_sym_else_directive_token1,
+      sym_directive,
   [27] = 3,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(101), 2,
+    ACTIONS(116), 6,
+      aux_sym__line_token1,
+      sym_comment,
+      anon_sym_DOT,
+      anon_sym_STAR,
+      sym_component,
+      sym_any_component,
+    ACTIONS(118), 12,
+      aux_sym_include_directive_token1,
+      aux_sym_define_directive_token1,
+      aux_sym_undef_directive_token1,
       aux_sym_if_directive_token1,
+      aux_sym_ifdef_directive_token1,
+      aux_sym_ifdef_directive_token2,
+      aux_sym__if_directive_body_token1,
       aux_sym_elif_directive_token1,
-    ACTIONS(99), 16,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
+      aux_sym_else_directive_token1,
+      sym_directive,
+  [54] = 3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(112), 7,
       ts_builtin_sym_end,
       aux_sym__line_token1,
       sym_comment,
@@ -1771,78 +2260,137 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_STAR,
       sym_component,
       sym_any_component,
+    ACTIONS(114), 7,
       aux_sym_include_directive_token1,
       aux_sym_define_directive_token1,
       aux_sym_undef_directive_token1,
+      aux_sym_if_directive_token1,
+      aux_sym_ifdef_directive_token1,
+      aux_sym_ifdef_directive_token2,
+      sym_directive,
+  [77] = 3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(116), 7,
+      ts_builtin_sym_end,
+      aux_sym__line_token1,
+      sym_comment,
+      anon_sym_DOT,
+      anon_sym_STAR,
+      sym_component,
+      sym_any_component,
+    ACTIONS(118), 7,
+      aux_sym_include_directive_token1,
+      aux_sym_define_directive_token1,
+      aux_sym_undef_directive_token1,
+      aux_sym_if_directive_token1,
+      aux_sym_ifdef_directive_token1,
+      aux_sym_ifdef_directive_token2,
+      sym_directive,
+  [100] = 3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(116), 6,
+      aux_sym__line_token1,
+      sym_comment,
+      anon_sym_DOT,
+      anon_sym_STAR,
+      sym_component,
+      sym_any_component,
+    ACTIONS(118), 8,
+      aux_sym_include_directive_token1,
+      aux_sym_define_directive_token1,
+      aux_sym_undef_directive_token1,
+      aux_sym_if_directive_token1,
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
       aux_sym__if_directive_body_token1,
-      aux_sym_elifdef_directive_token1,
-      aux_sym_elifdef_directive_token2,
-      aux_sym_else_directive_token1,
-  [54] = 8,
-    ACTIONS(29), 1,
-      aux_sym_elif_directive_token1,
-    ACTIONS(33), 1,
-      aux_sym_else_directive_token1,
-    ACTIONS(103), 1,
+      sym_directive,
+  [123] = 3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(112), 6,
+      aux_sym__line_token1,
+      sym_comment,
+      anon_sym_DOT,
+      anon_sym_STAR,
+      sym_component,
+      sym_any_component,
+    ACTIONS(114), 8,
+      aux_sym_include_directive_token1,
+      aux_sym_define_directive_token1,
+      aux_sym_undef_directive_token1,
+      aux_sym_if_directive_token1,
+      aux_sym_ifdef_directive_token1,
+      aux_sym_ifdef_directive_token2,
       aux_sym__if_directive_body_token1,
-    STATE(17), 1,
+      sym_directive,
+  [146] = 8,
+    ACTIONS(35), 1,
+      aux_sym_elif_directive_token1,
+    ACTIONS(120), 1,
+      aux_sym__if_directive_body_token1,
+    ACTIONS(124), 1,
+      aux_sym_else_directive_token1,
+    STATE(23), 1,
       aux_sym__if_directive_body_repeat1,
-    STATE(77), 1,
+    STATE(79), 1,
       sym_else_directive,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(31), 2,
+    ACTIONS(122), 2,
       aux_sym_elifdef_directive_token1,
       aux_sym_elifdef_directive_token2,
-    STATE(26), 2,
+    STATE(32), 2,
       sym_elif_directive,
       sym_elifdef_directive,
-  [82] = 8,
-    ACTIONS(29), 1,
+  [174] = 8,
+    ACTIONS(35), 1,
       aux_sym_elif_directive_token1,
-    ACTIONS(33), 1,
+    ACTIONS(124), 1,
       aux_sym_else_directive_token1,
-    ACTIONS(105), 1,
+    ACTIONS(126), 1,
       aux_sym__if_directive_body_token1,
-    STATE(17), 1,
+    STATE(23), 1,
       aux_sym__if_directive_body_repeat1,
-    STATE(67), 1,
+    STATE(69), 1,
       sym_else_directive,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(31), 2,
+    ACTIONS(122), 2,
       aux_sym_elifdef_directive_token1,
       aux_sym_elifdef_directive_token2,
-    STATE(26), 2,
+    STATE(32), 2,
       sym_elif_directive,
       sym_elifdef_directive,
-  [110] = 6,
-    ACTIONS(109), 1,
+  [202] = 6,
+    ACTIONS(130), 1,
       aux_sym_elif_directive_token1,
-    STATE(17), 1,
+    STATE(23), 1,
       aux_sym__if_directive_body_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(107), 2,
+    ACTIONS(128), 2,
       aux_sym__if_directive_body_token1,
       aux_sym_else_directive_token1,
-    ACTIONS(112), 2,
+    ACTIONS(133), 2,
       aux_sym_elifdef_directive_token1,
       aux_sym_elifdef_directive_token2,
-    STATE(26), 2,
+    STATE(32), 2,
       sym_elif_directive,
       sym_elifdef_directive,
-  [133] = 6,
+  [225] = 6,
     ACTIONS(15), 1,
       sym_any_component,
-    ACTIONS(115), 1,
+    ACTIONS(136), 1,
       sym_component,
-    STATE(38), 1,
+    STATE(45), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1850,52 +2398,37 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(19), 2,
+    STATE(26), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [155] = 4,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(117), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    ACTIONS(120), 2,
-      sym_component,
-      sym_any_component,
-    STATE(19), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [172] = 4,
+  [247] = 4,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    ACTIONS(122), 2,
+    ACTIONS(138), 2,
       sym_component,
       sym_any_component,
-    STATE(19), 2,
+    STATE(26), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [189] = 7,
-    ACTIONS(3), 1,
+  [264] = 4,
+    ACTIONS(3), 2,
       sym_preprocessor_comment,
-    ACTIONS(124), 1,
       aux_sym_resource_token1,
-    ACTIONS(126), 1,
-      sym_escape_sequence,
-    ACTIONS(128), 1,
-      aux_sym_resource_value_token1,
-    STATE(23), 1,
-      aux_sym_resource_repeat1,
-    STATE(31), 1,
-      aux_sym_resource_value_repeat1,
-    STATE(71), 1,
-      sym_resource_value,
-  [211] = 4,
-    ACTIONS(130), 1,
+    ACTIONS(140), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    ACTIONS(143), 2,
+      sym_component,
+      sym_any_component,
+    STATE(26), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [281] = 4,
+    ACTIONS(145), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1903,26 +2436,53 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(20), 2,
+    STATE(25), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [227] = 7,
+  [297] = 7,
     ACTIONS(3), 1,
       sym_preprocessor_comment,
-    ACTIONS(126), 1,
-      sym_escape_sequence,
-    ACTIONS(128), 1,
-      aux_sym_resource_value_token1,
-    ACTIONS(132), 1,
+    ACTIONS(147), 1,
       aux_sym_resource_token1,
-    STATE(31), 1,
+    ACTIONS(149), 1,
+      sym_escape_sequence,
+    ACTIONS(151), 1,
+      aux_sym_resource_value_token1,
+    STATE(30), 1,
+      aux_sym_resource_repeat1,
+    STATE(35), 1,
+      aux_sym_resource_value_repeat1,
+    STATE(56), 1,
+      sym_resource_value,
+  [319] = 4,
+    ACTIONS(153), 1,
+      anon_sym_COLON,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    STATE(25), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [335] = 7,
+    ACTIONS(3), 1,
+      sym_preprocessor_comment,
+    ACTIONS(149), 1,
+      sym_escape_sequence,
+    ACTIONS(151), 1,
+      aux_sym_resource_value_token1,
+    ACTIONS(155), 1,
+      aux_sym_resource_token1,
+    STATE(35), 1,
       aux_sym_resource_value_repeat1,
     STATE(39), 1,
       aux_sym_resource_repeat1,
-    STATE(53), 1,
+    STATE(55), 1,
       sym_resource_value,
-  [249] = 4,
-    ACTIONS(134), 1,
+  [357] = 4,
+    ACTIONS(157), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1930,420 +2490,434 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(20), 2,
+    STATE(25), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [265] = 4,
-    ACTIONS(136), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    STATE(20), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [281] = 3,
-    ACTIONS(140), 1,
+  [373] = 3,
+    ACTIONS(161), 1,
       aux_sym_elif_directive_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(138), 4,
+    ACTIONS(159), 4,
       aux_sym__if_directive_body_token1,
       aux_sym_elifdef_directive_token1,
       aux_sym_elifdef_directive_token2,
       aux_sym_else_directive_token1,
-  [295] = 3,
+  [387] = 3,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(20), 2,
+    STATE(25), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [308] = 5,
-    ACTIONS(142), 1,
+  [400] = 5,
+    ACTIONS(163), 1,
       aux_sym__line_token1,
-    ACTIONS(144), 1,
-      sym_escape_sequence,
-    ACTIONS(147), 1,
-      aux_sym_resource_value_token1,
-    STATE(28), 1,
-      aux_sym_resource_value_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [325] = 5,
-    ACTIONS(150), 1,
-      aux_sym__line_token1,
-    ACTIONS(152), 1,
+    ACTIONS(165), 1,
       anon_sym_LPAREN,
-    ACTIONS(154), 1,
+    ACTIONS(167), 1,
       sym_expansion,
-    STATE(45), 1,
+    STATE(51), 1,
       sym_parameters,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [342] = 2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(156), 4,
-      anon_sym_DOT,
-      anon_sym_STAR,
-      sym_component,
-      sym_any_component,
-  [353] = 5,
-    ACTIONS(158), 1,
+  [417] = 5,
+    ACTIONS(169), 1,
       aux_sym__line_token1,
-    ACTIONS(160), 1,
+    ACTIONS(171), 1,
       sym_escape_sequence,
-    ACTIONS(162), 1,
+    ACTIONS(173), 1,
       aux_sym_resource_value_token1,
-    STATE(28), 1,
+    STATE(36), 1,
       aux_sym_resource_value_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [370] = 3,
-    STATE(32), 1,
-      aux_sym_components_repeat2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(164), 2,
-      sym_component,
-      sym_any_component,
-  [382] = 3,
-    ACTIONS(169), 1,
-      anon_sym_RPAREN,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(167), 2,
-      anon_sym_DOT_DOT_DOT,
-      sym_identifier,
-  [394] = 4,
-    ACTIONS(171), 1,
-      anon_sym_COMMA,
-    ACTIONS(173), 1,
-      anon_sym_RPAREN,
-    STATE(35), 1,
-      aux_sym_parameters_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [408] = 4,
-    ACTIONS(171), 1,
-      anon_sym_COMMA,
+  [434] = 5,
     ACTIONS(175), 1,
-      anon_sym_RPAREN,
-    STATE(36), 1,
-      aux_sym_parameters_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [422] = 4,
+      aux_sym__line_token1,
     ACTIONS(177), 1,
-      anon_sym_COMMA,
+      sym_escape_sequence,
     ACTIONS(180), 1,
-      anon_sym_RPAREN,
+      aux_sym_resource_value_token1,
     STATE(36), 1,
-      aux_sym_parameters_repeat1,
+      aux_sym_resource_value_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [436] = 4,
+  [451] = 2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(183), 4,
+      anon_sym_DOT,
+      anon_sym_STAR,
+      sym_component,
+      sym_any_component,
+  [462] = 4,
     ACTIONS(15), 1,
       sym_any_component,
-    ACTIONS(115), 1,
+    ACTIONS(136), 1,
       sym_component,
-    STATE(32), 1,
+    STATE(42), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [450] = 4,
-    ACTIONS(15), 1,
-      sym_any_component,
-    ACTIONS(182), 1,
-      sym_component,
-    STATE(32), 1,
-      aux_sym_components_repeat2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [464] = 5,
+  [476] = 5,
     ACTIONS(3), 1,
       sym_preprocessor_comment,
-    ACTIONS(184), 1,
+    ACTIONS(185), 1,
       aux_sym_resource_token1,
-    ACTIONS(187), 1,
+    ACTIONS(188), 1,
       sym_escape_sequence,
-    ACTIONS(189), 1,
+    ACTIONS(190), 1,
       aux_sym_resource_value_token1,
     STATE(39), 1,
       aux_sym_resource_repeat1,
-  [480] = 2,
+  [492] = 4,
+    ACTIONS(192), 1,
+      anon_sym_COMMA,
+    ACTIONS(194), 1,
+      anon_sym_RPAREN,
+    STATE(41), 1,
+      aux_sym_parameters_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(180), 2,
+  [506] = 4,
+    ACTIONS(192), 1,
       anon_sym_COMMA,
+    ACTIONS(196), 1,
       anon_sym_RPAREN,
-  [489] = 3,
-    ACTIONS(191), 1,
+    STATE(43), 1,
+      aux_sym_parameters_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [520] = 3,
+    STATE(42), 1,
+      aux_sym_components_repeat2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(198), 2,
+      sym_component,
+      sym_any_component,
+  [532] = 4,
+    ACTIONS(201), 1,
+      anon_sym_COMMA,
+    ACTIONS(204), 1,
+      anon_sym_RPAREN,
+    STATE(43), 1,
+      aux_sym_parameters_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [546] = 3,
+    ACTIONS(208), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(206), 2,
+      anon_sym_DOT_DOT_DOT,
+      sym_identifier,
+  [558] = 4,
+    ACTIONS(15), 1,
+      sym_any_component,
+    ACTIONS(210), 1,
+      sym_component,
+    STATE(42), 1,
+      aux_sym_components_repeat2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [572] = 3,
+    ACTIONS(212), 1,
+      aux_sym__line_token1,
+    ACTIONS(214), 1,
+      sym_expansion,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [583] = 3,
+    ACTIONS(216), 1,
+      aux_sym__line_token1,
+    ACTIONS(218), 1,
+      sym_expansion,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [594] = 3,
+    ACTIONS(220), 1,
       anon_sym_DQUOTE,
-    STATE(68), 1,
+    STATE(61), 1,
       sym_string,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [500] = 3,
-    ACTIONS(193), 1,
-      aux_sym__line_token1,
-    ACTIONS(195), 1,
-      sym_expansion,
+  [605] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [511] = 2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(197), 2,
+    ACTIONS(222), 2,
       anon_sym_DOT_DOT_DOT,
       sym_identifier,
-  [520] = 3,
-    ACTIONS(199), 1,
+  [614] = 3,
+    ACTIONS(224), 1,
       aux_sym__line_token1,
-    ACTIONS(201), 1,
+    ACTIONS(226), 1,
       sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [531] = 3,
-    ACTIONS(203), 1,
+  [625] = 3,
+    ACTIONS(228), 1,
       aux_sym__line_token1,
-    ACTIONS(205), 1,
+    ACTIONS(230), 1,
       sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [542] = 3,
-    ACTIONS(207), 1,
+  [636] = 2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(204), 2,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+  [645] = 3,
+    ACTIONS(232), 1,
       aux_sym__line_token1,
-    ACTIONS(209), 1,
+    ACTIONS(234), 1,
       sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [553] = 2,
-    ACTIONS(213), 1,
-      aux_sym_string_token1,
-    ACTIONS(211), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [561] = 2,
-    ACTIONS(215), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [569] = 2,
-    ACTIONS(217), 1,
+  [656] = 2,
+    ACTIONS(236), 1,
       aux_sym__if_directive_body_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [577] = 2,
-    ACTIONS(219), 1,
+  [664] = 2,
+    ACTIONS(238), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [672] = 2,
+    ACTIONS(240), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [680] = 2,
+    ACTIONS(242), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [688] = 2,
+    ACTIONS(244), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [696] = 2,
+    ACTIONS(246), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [585] = 2,
-    ACTIONS(221), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [593] = 2,
-    ACTIONS(223), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [601] = 2,
-    ACTIONS(225), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [609] = 2,
-    ACTIONS(227), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [617] = 2,
-    ACTIONS(229), 1,
-      sym_expansion,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [625] = 2,
-    ACTIONS(231), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [633] = 2,
-    ACTIONS(233), 1,
-      sym_expansion,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [641] = 2,
-    ACTIONS(235), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [649] = 2,
-    ACTIONS(237), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [657] = 2,
-    ACTIONS(239), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [665] = 2,
-    ACTIONS(241), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [673] = 2,
-    ACTIONS(243), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [681] = 2,
-    ACTIONS(245), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [689] = 2,
-    ACTIONS(247), 1,
+  [704] = 2,
+    ACTIONS(248), 1,
       aux_sym__if_directive_body_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [697] = 2,
-    ACTIONS(249), 1,
+  [712] = 2,
+    ACTIONS(250), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [720] = 2,
+    ACTIONS(252), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [705] = 2,
-    ACTIONS(251), 1,
+  [728] = 2,
+    ACTIONS(254), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [713] = 2,
-    ACTIONS(253), 1,
+  [736] = 2,
+    ACTIONS(256), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [744] = 2,
+    ACTIONS(258), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [752] = 2,
+    ACTIONS(260), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [760] = 2,
+    ACTIONS(262), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [768] = 2,
+    ACTIONS(264), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [776] = 2,
+    ACTIONS(266), 1,
       aux_sym__if_directive_body_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [721] = 2,
-    ACTIONS(255), 1,
+  [784] = 2,
+    ACTIONS(268), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [792] = 2,
+    ACTIONS(270), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [800] = 2,
+    ACTIONS(274), 1,
+      aux_sym_string_token1,
+    ACTIONS(272), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [808] = 2,
+    ACTIONS(276), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [729] = 2,
-    ACTIONS(257), 1,
+  [816] = 2,
+    ACTIONS(278), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [824] = 2,
+    ACTIONS(280), 1,
+      sym_expansion,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [832] = 2,
+    ACTIONS(282), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [840] = 2,
+    ACTIONS(284), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [848] = 2,
+    ACTIONS(286), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [856] = 2,
+    ACTIONS(288), 1,
+      aux_sym__if_directive_body_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [864] = 2,
+    ACTIONS(290), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [872] = 2,
+    ACTIONS(292), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [880] = 2,
+    ACTIONS(294), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [888] = 2,
+    ACTIONS(296), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [737] = 2,
-    ACTIONS(259), 1,
+  [896] = 2,
+    ACTIONS(298), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [745] = 2,
-    ACTIONS(261), 1,
+  [904] = 2,
+    ACTIONS(300), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [753] = 2,
-    ACTIONS(263), 1,
+  [912] = 2,
+    ACTIONS(302), 1,
+      sym_expansion,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [920] = 2,
+    ACTIONS(304), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [928] = 2,
+    ACTIONS(306), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [761] = 2,
-    ACTIONS(265), 1,
+  [936] = 2,
+    ACTIONS(308), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [769] = 2,
-    ACTIONS(267), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [777] = 2,
-    ACTIONS(269), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [785] = 2,
-    ACTIONS(271), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [793] = 2,
-    ACTIONS(273), 1,
-      aux_sym__if_directive_body_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [801] = 2,
-    ACTIONS(275), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [809] = 2,
-    ACTIONS(277), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [817] = 2,
-    ACTIONS(279), 1,
+  [944] = 2,
+    ACTIONS(310), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -2351,74 +2925,82 @@ static const uint16_t ts_small_parse_table[] = {
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(13)] = 0,
-  [SMALL_STATE(14)] = 27,
-  [SMALL_STATE(15)] = 54,
-  [SMALL_STATE(16)] = 82,
-  [SMALL_STATE(17)] = 110,
-  [SMALL_STATE(18)] = 133,
-  [SMALL_STATE(19)] = 155,
-  [SMALL_STATE(20)] = 172,
-  [SMALL_STATE(21)] = 189,
-  [SMALL_STATE(22)] = 211,
-  [SMALL_STATE(23)] = 227,
-  [SMALL_STATE(24)] = 249,
-  [SMALL_STATE(25)] = 265,
-  [SMALL_STATE(26)] = 281,
-  [SMALL_STATE(27)] = 295,
-  [SMALL_STATE(28)] = 308,
-  [SMALL_STATE(29)] = 325,
-  [SMALL_STATE(30)] = 342,
-  [SMALL_STATE(31)] = 353,
-  [SMALL_STATE(32)] = 370,
-  [SMALL_STATE(33)] = 382,
-  [SMALL_STATE(34)] = 394,
-  [SMALL_STATE(35)] = 408,
-  [SMALL_STATE(36)] = 422,
-  [SMALL_STATE(37)] = 436,
-  [SMALL_STATE(38)] = 450,
-  [SMALL_STATE(39)] = 464,
-  [SMALL_STATE(40)] = 480,
-  [SMALL_STATE(41)] = 489,
-  [SMALL_STATE(42)] = 500,
-  [SMALL_STATE(43)] = 511,
-  [SMALL_STATE(44)] = 520,
-  [SMALL_STATE(45)] = 531,
-  [SMALL_STATE(46)] = 542,
-  [SMALL_STATE(47)] = 553,
-  [SMALL_STATE(48)] = 561,
-  [SMALL_STATE(49)] = 569,
-  [SMALL_STATE(50)] = 577,
-  [SMALL_STATE(51)] = 585,
-  [SMALL_STATE(52)] = 593,
-  [SMALL_STATE(53)] = 601,
-  [SMALL_STATE(54)] = 609,
-  [SMALL_STATE(55)] = 617,
-  [SMALL_STATE(56)] = 625,
-  [SMALL_STATE(57)] = 633,
-  [SMALL_STATE(58)] = 641,
-  [SMALL_STATE(59)] = 649,
-  [SMALL_STATE(60)] = 657,
-  [SMALL_STATE(61)] = 665,
-  [SMALL_STATE(62)] = 673,
-  [SMALL_STATE(63)] = 681,
-  [SMALL_STATE(64)] = 689,
-  [SMALL_STATE(65)] = 697,
-  [SMALL_STATE(66)] = 705,
-  [SMALL_STATE(67)] = 713,
-  [SMALL_STATE(68)] = 721,
-  [SMALL_STATE(69)] = 729,
-  [SMALL_STATE(70)] = 737,
-  [SMALL_STATE(71)] = 745,
-  [SMALL_STATE(72)] = 753,
-  [SMALL_STATE(73)] = 761,
-  [SMALL_STATE(74)] = 769,
-  [SMALL_STATE(75)] = 777,
-  [SMALL_STATE(76)] = 785,
-  [SMALL_STATE(77)] = 793,
-  [SMALL_STATE(78)] = 801,
-  [SMALL_STATE(79)] = 809,
-  [SMALL_STATE(80)] = 817,
+  [SMALL_STATE(15)] = 0,
+  [SMALL_STATE(16)] = 27,
+  [SMALL_STATE(17)] = 54,
+  [SMALL_STATE(18)] = 77,
+  [SMALL_STATE(19)] = 100,
+  [SMALL_STATE(20)] = 123,
+  [SMALL_STATE(21)] = 146,
+  [SMALL_STATE(22)] = 174,
+  [SMALL_STATE(23)] = 202,
+  [SMALL_STATE(24)] = 225,
+  [SMALL_STATE(25)] = 247,
+  [SMALL_STATE(26)] = 264,
+  [SMALL_STATE(27)] = 281,
+  [SMALL_STATE(28)] = 297,
+  [SMALL_STATE(29)] = 319,
+  [SMALL_STATE(30)] = 335,
+  [SMALL_STATE(31)] = 357,
+  [SMALL_STATE(32)] = 373,
+  [SMALL_STATE(33)] = 387,
+  [SMALL_STATE(34)] = 400,
+  [SMALL_STATE(35)] = 417,
+  [SMALL_STATE(36)] = 434,
+  [SMALL_STATE(37)] = 451,
+  [SMALL_STATE(38)] = 462,
+  [SMALL_STATE(39)] = 476,
+  [SMALL_STATE(40)] = 492,
+  [SMALL_STATE(41)] = 506,
+  [SMALL_STATE(42)] = 520,
+  [SMALL_STATE(43)] = 532,
+  [SMALL_STATE(44)] = 546,
+  [SMALL_STATE(45)] = 558,
+  [SMALL_STATE(46)] = 572,
+  [SMALL_STATE(47)] = 583,
+  [SMALL_STATE(48)] = 594,
+  [SMALL_STATE(49)] = 605,
+  [SMALL_STATE(50)] = 614,
+  [SMALL_STATE(51)] = 625,
+  [SMALL_STATE(52)] = 636,
+  [SMALL_STATE(53)] = 645,
+  [SMALL_STATE(54)] = 656,
+  [SMALL_STATE(55)] = 664,
+  [SMALL_STATE(56)] = 672,
+  [SMALL_STATE(57)] = 680,
+  [SMALL_STATE(58)] = 688,
+  [SMALL_STATE(59)] = 696,
+  [SMALL_STATE(60)] = 704,
+  [SMALL_STATE(61)] = 712,
+  [SMALL_STATE(62)] = 720,
+  [SMALL_STATE(63)] = 728,
+  [SMALL_STATE(64)] = 736,
+  [SMALL_STATE(65)] = 744,
+  [SMALL_STATE(66)] = 752,
+  [SMALL_STATE(67)] = 760,
+  [SMALL_STATE(68)] = 768,
+  [SMALL_STATE(69)] = 776,
+  [SMALL_STATE(70)] = 784,
+  [SMALL_STATE(71)] = 792,
+  [SMALL_STATE(72)] = 800,
+  [SMALL_STATE(73)] = 808,
+  [SMALL_STATE(74)] = 816,
+  [SMALL_STATE(75)] = 824,
+  [SMALL_STATE(76)] = 832,
+  [SMALL_STATE(77)] = 840,
+  [SMALL_STATE(78)] = 848,
+  [SMALL_STATE(79)] = 856,
+  [SMALL_STATE(80)] = 864,
+  [SMALL_STATE(81)] = 872,
+  [SMALL_STATE(82)] = 880,
+  [SMALL_STATE(83)] = 888,
+  [SMALL_STATE(84)] = 896,
+  [SMALL_STATE(85)] = 904,
+  [SMALL_STATE(86)] = 912,
+  [SMALL_STATE(87)] = 920,
+  [SMALL_STATE(88)] = 928,
+  [SMALL_STATE(89)] = 936,
+  [SMALL_STATE(90)] = 944,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -2426,134 +3008,147 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 0, 0, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
-  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(13),
-  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(48),
-  [47] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(30),
-  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
-  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
-  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(41),
-  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(51),
-  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(54),
-  [65] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(55),
-  [68] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(58),
-  [71] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
-  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elif_directive, 2, 0, 10),
-  [75] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_directive, 2, 0, 10),
-  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elifdef_directive, 2, 0, 10),
-  [79] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elifdef_directive, 2, 0, 10),
-  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elif_directive, 3, 0, 10),
-  [83] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_directive, 3, 0, 10),
-  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elifdef_directive, 3, 0, 10),
-  [87] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elifdef_directive, 3, 0, 10),
-  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
-  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
-  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
-  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
-  [101] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line, 2, 0, 0),
-  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__if_directive_body_repeat1, 2, 0, 13),
-  [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__if_directive_body_repeat1, 2, 0, 13), SHIFT_REPEAT(57),
-  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__if_directive_body_repeat1, 2, 0, 13), SHIFT_REPEAT(65),
-  [115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [117] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(30),
-  [120] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
-  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
-  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [128] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
-  [130] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [134] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
-  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
-  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__if_directive_body_repeat1, 1, 0, 8),
-  [140] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__if_directive_body_repeat1, 1, 0, 8),
-  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
-  [144] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
-  [147] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
-  [150] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
-  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [154] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
-  [156] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
-  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
-  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [162] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
-  [164] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(27),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [177] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0), SHIFT_REPEAT(43),
-  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0),
-  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [184] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(39),
-  [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [189] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [193] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 2, 0, 0),
-  [195] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 2, 0, 0),
-  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 3, 0, 0),
-  [201] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 3, 0, 0),
-  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 3, 0, 4),
-  [205] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
-  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 4, 0, 0),
-  [209] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 4, 0, 0),
-  [211] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [213] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
-  [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [219] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 7),
-  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 9),
-  [227] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [229] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
-  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 4, 0, 6),
-  [233] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
-  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
-  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
-  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 2, 0, 8),
-  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_directive, 4, 0, 7),
-  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 2, 0, 12),
-  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
-  [257] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 5),
-  [263] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_undef_directive, 2, 0, 2),
-  [265] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 3, 0, 14),
-  [271] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 3, 0, 15),
-  [273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 3, 0, 16),
-  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 4, 0, 17),
-  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 2, 0, 11),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(86),
+  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
+  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
+  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(84),
+  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
+  [45] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elifdef_directive, 2, 0, 12),
+  [47] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_directive, 2, 0, 12),
+  [49] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_directive, 3, 0, 12),
+  [51] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elifdef_directive, 3, 0, 12),
+  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(16),
+  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(88),
+  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(37),
+  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
+  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
+  [68] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(48),
+  [71] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(62),
+  [74] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(71),
+  [77] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(75),
+  [80] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(76),
+  [83] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
+  [85] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(46),
+  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
+  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(89),
+  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
+  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [100] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_else_directive, 2, 0, 0),
+  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
+  [104] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
+  [107] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(82),
+  [110] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_else_directive, 3, 0, 0),
+  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
+  [114] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line, 2, 0, 0),
+  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
+  [118] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
+  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__if_directive_body_repeat1, 2, 0, 15),
+  [130] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__if_directive_body_repeat1, 2, 0, 15), SHIFT_REPEAT(86),
+  [133] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__if_directive_body_repeat1, 2, 0, 15), SHIFT_REPEAT(70),
+  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
+  [140] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(37),
+  [143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
+  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
+  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [151] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
+  [153] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
+  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
+  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__if_directive_body_repeat1, 1, 0, 10),
+  [161] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__if_directive_body_repeat1, 1, 0, 10),
+  [163] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 3),
+  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [167] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [169] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [173] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
+  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
+  [177] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(36),
+  [180] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(36),
+  [183] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
+  [185] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(39),
+  [188] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [190] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [198] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(33),
+  [201] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0), SHIFT_REPEAT(49),
+  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0),
+  [206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [208] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [210] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_simple_directive, 1, 0, 1),
+  [214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
+  [216] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 2, 0, 0),
+  [218] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 2, 0, 0),
+  [220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [224] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 3, 0, 0),
+  [226] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 3, 0, 0),
+  [228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 3, 0, 6),
+  [230] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
+  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 4, 0, 0),
+  [234] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 4, 0, 0),
+  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [238] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 11),
+  [240] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 7),
+  [242] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [244] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_directive, 4, 0, 9),
+  [246] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [248] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [250] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 2),
+  [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [254] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_undef_directive, 2, 0, 3),
+  [256] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 2, 0, 10),
+  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 2, 0, 13),
+  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 5),
+  [262] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [264] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 2, 0, 14),
+  [266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [272] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [274] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
+  [276] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
+  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_simple_directive, 2, 0, 4),
+  [280] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 3, 0, 16),
+  [286] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 3, 0, 17),
+  [288] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [290] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 3, 0, 18),
+  [292] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 4, 0, 19),
+  [294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [296] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 9),
+  [300] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 4, 0, 8),
+  [302] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
+  [304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,14 +5,14 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 74
-#define LARGE_STATE_COUNT 10
-#define SYMBOL_COUNT 52
+#define STATE_COUNT 81
+#define LARGE_STATE_COUNT 13
+#define SYMBOL_COUNT 57
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 29
+#define TOKEN_COUNT 31
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 7
-#define MAX_ALIAS_SEQUENCE_LENGTH 7
+#define MAX_ALIAS_SEQUENCE_LENGTH 4
 #define PRODUCTION_ID_COUNT 18
 
 enum ts_symbol_identifiers {
@@ -37,37 +37,42 @@ enum ts_symbol_identifiers {
   anon_sym_RPAREN = 19,
   sym_expansion = 20,
   aux_sym_undef_directive_token1 = 21,
-  aux_sym_ifdef_directive_token1 = 22,
-  aux_sym_ifdef_directive_token2 = 23,
-  aux_sym_ifdef_directive_token3 = 24,
-  aux_sym_elifdef_directive_token1 = 25,
-  aux_sym_elifdef_directive_token2 = 26,
-  aux_sym_else_directive_token1 = 27,
-  sym_identifier = 28,
-  sym_resources = 29,
-  sym__line = 30,
-  sym__statement = 31,
-  sym_resource = 32,
-  sym_components = 33,
-  sym_binding = 34,
-  sym_resource_value = 35,
-  sym_string = 36,
-  sym_include_directive = 37,
-  sym_define_directive = 38,
-  sym_define_function_directive = 39,
-  sym_parameters = 40,
-  sym_undef_directive = 41,
-  sym_ifdef_directive = 42,
-  sym_elifdef_directive = 43,
-  sym_else_directive = 44,
-  aux_sym_resources_repeat1 = 45,
-  aux_sym_resource_repeat1 = 46,
-  aux_sym_components_repeat1 = 47,
-  aux_sym_components_repeat2 = 48,
-  aux_sym_resource_value_repeat1 = 49,
-  aux_sym_parameters_repeat1 = 50,
-  aux_sym_ifdef_directive_repeat1 = 51,
-  alias_sym_body = 52,
+  aux_sym_if_directive_token1 = 22,
+  aux_sym_ifdef_directive_token1 = 23,
+  aux_sym_ifdef_directive_token2 = 24,
+  aux_sym__if_directive_body_token1 = 25,
+  aux_sym_elif_directive_token1 = 26,
+  aux_sym_elifdef_directive_token1 = 27,
+  aux_sym_elifdef_directive_token2 = 28,
+  aux_sym_else_directive_token1 = 29,
+  sym_identifier = 30,
+  sym_resources = 31,
+  sym__line = 32,
+  sym__statement = 33,
+  sym_resource = 34,
+  sym_components = 35,
+  sym_binding = 36,
+  sym_resource_value = 37,
+  sym_string = 38,
+  sym_include_directive = 39,
+  sym_define_directive = 40,
+  sym_define_function_directive = 41,
+  sym_parameters = 42,
+  sym_undef_directive = 43,
+  sym_if_directive = 44,
+  sym_ifdef_directive = 45,
+  sym__if_directive_body = 46,
+  sym_elif_directive = 47,
+  sym_elifdef_directive = 48,
+  sym_else_directive = 49,
+  aux_sym_resources_repeat1 = 50,
+  aux_sym_resource_repeat1 = 51,
+  aux_sym_components_repeat1 = 52,
+  aux_sym_components_repeat2 = 53,
+  aux_sym_resource_value_repeat1 = 54,
+  aux_sym_parameters_repeat1 = 55,
+  aux_sym__if_directive_body_repeat1 = 56,
+  alias_sym_body = 57,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -93,9 +98,11 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_RPAREN] = ")",
   [sym_expansion] = "expansion",
   [aux_sym_undef_directive_token1] = "#undef",
+  [aux_sym_if_directive_token1] = "#if",
   [aux_sym_ifdef_directive_token1] = "#ifdef",
   [aux_sym_ifdef_directive_token2] = "#ifndef",
-  [aux_sym_ifdef_directive_token3] = "#endif",
+  [aux_sym__if_directive_body_token1] = "#endif",
+  [aux_sym_elif_directive_token1] = "#elif",
   [aux_sym_elifdef_directive_token1] = "#elifdef",
   [aux_sym_elifdef_directive_token2] = "#elifndef",
   [aux_sym_else_directive_token1] = "#else",
@@ -113,7 +120,10 @@ static const char * const ts_symbol_names[] = {
   [sym_define_function_directive] = "define_function_directive",
   [sym_parameters] = "parameters",
   [sym_undef_directive] = "undef_directive",
+  [sym_if_directive] = "if_directive",
   [sym_ifdef_directive] = "ifdef_directive",
+  [sym__if_directive_body] = "_if_directive_body",
+  [sym_elif_directive] = "elif_directive",
   [sym_elifdef_directive] = "elifdef_directive",
   [sym_else_directive] = "else_directive",
   [aux_sym_resources_repeat1] = "resources_repeat1",
@@ -122,7 +132,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_components_repeat2] = "components_repeat2",
   [aux_sym_resource_value_repeat1] = "resource_value_repeat1",
   [aux_sym_parameters_repeat1] = "parameters_repeat1",
-  [aux_sym_ifdef_directive_repeat1] = "ifdef_directive_repeat1",
+  [aux_sym__if_directive_body_repeat1] = "_if_directive_body_repeat1",
   [alias_sym_body] = "body",
 };
 
@@ -149,9 +159,11 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_RPAREN] = anon_sym_RPAREN,
   [sym_expansion] = sym_expansion,
   [aux_sym_undef_directive_token1] = aux_sym_undef_directive_token1,
+  [aux_sym_if_directive_token1] = aux_sym_if_directive_token1,
   [aux_sym_ifdef_directive_token1] = aux_sym_ifdef_directive_token1,
   [aux_sym_ifdef_directive_token2] = aux_sym_ifdef_directive_token2,
-  [aux_sym_ifdef_directive_token3] = aux_sym_ifdef_directive_token3,
+  [aux_sym__if_directive_body_token1] = aux_sym__if_directive_body_token1,
+  [aux_sym_elif_directive_token1] = aux_sym_elif_directive_token1,
   [aux_sym_elifdef_directive_token1] = aux_sym_elifdef_directive_token1,
   [aux_sym_elifdef_directive_token2] = aux_sym_elifdef_directive_token2,
   [aux_sym_else_directive_token1] = aux_sym_else_directive_token1,
@@ -169,7 +181,10 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_define_function_directive] = sym_define_function_directive,
   [sym_parameters] = sym_parameters,
   [sym_undef_directive] = sym_undef_directive,
+  [sym_if_directive] = sym_if_directive,
   [sym_ifdef_directive] = sym_ifdef_directive,
+  [sym__if_directive_body] = sym__if_directive_body,
+  [sym_elif_directive] = sym_elif_directive,
   [sym_elifdef_directive] = sym_elifdef_directive,
   [sym_else_directive] = sym_else_directive,
   [aux_sym_resources_repeat1] = aux_sym_resources_repeat1,
@@ -178,7 +193,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_components_repeat2] = aux_sym_components_repeat2,
   [aux_sym_resource_value_repeat1] = aux_sym_resource_value_repeat1,
   [aux_sym_parameters_repeat1] = aux_sym_parameters_repeat1,
-  [aux_sym_ifdef_directive_repeat1] = aux_sym_ifdef_directive_repeat1,
+  [aux_sym__if_directive_body_repeat1] = aux_sym__if_directive_body_repeat1,
   [alias_sym_body] = alias_sym_body,
 };
 
@@ -271,6 +286,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [aux_sym_if_directive_token1] = {
+    .visible = true,
+    .named = false,
+  },
   [aux_sym_ifdef_directive_token1] = {
     .visible = true,
     .named = false,
@@ -279,7 +298,11 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_ifdef_directive_token3] = {
+  [aux_sym__if_directive_body_token1] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_elif_directive_token1] = {
     .visible = true,
     .named = false,
   },
@@ -351,7 +374,19 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_if_directive] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_ifdef_directive] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym__if_directive_body] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_elif_directive] = {
     .visible = true,
     .named = true,
   },
@@ -387,7 +422,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_ifdef_directive_repeat1] = {
+  [aux_sym__if_directive_body_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -425,17 +460,17 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [4] = {.index = 4, .length = 2},
   [5] = {.index = 6, .length = 2},
   [6] = {.index = 8, .length = 3},
-  [7] = {.index = 11, .length = 1},
-  [8] = {.index = 12, .length = 1},
-  [9] = {.index = 13, .length = 2},
-  [10] = {.index = 15, .length = 2},
-  [11] = {.index = 17, .length = 2},
-  [12] = {.index = 19, .length = 2},
-  [13] = {.index = 21, .length = 2},
-  [14] = {.index = 23, .length = 3},
-  [15] = {.index = 26, .length = 3},
-  [16] = {.index = 29, .length = 3},
-  [17] = {.index = 32, .length = 4},
+  [7] = {.index = 11, .length = 3},
+  [8] = {.index = 14, .length = 1},
+  [9] = {.index = 15, .length = 2},
+  [10] = {.index = 17, .length = 1},
+  [11] = {.index = 18, .length = 1},
+  [12] = {.index = 19, .length = 1},
+  [13] = {.index = 20, .length = 2},
+  [14] = {.index = 22, .length = 2},
+  [15] = {.index = 24, .length = 2},
+  [16] = {.index = 26, .length = 2},
+  [17] = {.index = 28, .length = 3},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -457,56 +492,51 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
     {field_parameters, 2},
     {field_value, 3},
   [11] =
+    {field_alternative, 3, .inherited = true},
     {field_condition, 1},
-  [12] =
+    {field_consequence, 3, .inherited = true},
+  [14] =
     {field_alternative, 0},
-  [13] =
+  [15] =
     {field_name, 0},
     {field_value, 3},
-  [15] =
-    {field_alternative, 3},
-    {field_condition, 1},
   [17] =
     {field_condition, 1},
-    {field_consequence, 3},
+  [18] =
+    {field_consequence, 0},
   [19] =
-    {field_alternative, 3, .inherited = true},
-    {field_condition, 1},
-  [21] =
+    {field_alternative, 0, .inherited = true},
+  [20] =
     {field_alternative, 0, .inherited = true},
     {field_alternative, 1, .inherited = true},
-  [23] =
-    {field_alternative, 4},
-    {field_condition, 1},
-    {field_consequence, 3},
+  [22] =
+    {field_alternative, 1},
+    {field_consequence, 0},
+  [24] =
+    {field_alternative, 1, .inherited = true},
+    {field_consequence, 0},
   [26] =
-    {field_alternative, 4, .inherited = true},
-    {field_condition, 1},
-    {field_consequence, 3},
-  [29] =
-    {field_alternative, 3, .inherited = true},
-    {field_alternative, 4},
-    {field_condition, 1},
-  [32] =
-    {field_alternative, 4, .inherited = true},
-    {field_alternative, 5},
-    {field_condition, 1},
-    {field_consequence, 3},
+    {field_alternative, 0, .inherited = true},
+    {field_alternative, 1},
+  [28] =
+    {field_alternative, 1, .inherited = true},
+    {field_alternative, 2},
+    {field_consequence, 0},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
   [11] = {
-    [3] = alias_sym_body,
+    [0] = alias_sym_body,
   },
   [14] = {
-    [3] = alias_sym_body,
+    [0] = alias_sym_body,
   },
   [15] = {
-    [3] = alias_sym_body,
+    [0] = alias_sym_body,
   },
   [17] = {
-    [3] = alias_sym_body,
+    [0] = alias_sym_body,
   },
 };
 
@@ -592,6 +622,13 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [71] = 71,
   [72] = 72,
   [73] = 73,
+  [74] = 74,
+  [75] = 75,
+  [76] = 76,
+  [77] = 77,
+  [78] = 78,
+  [79] = 79,
+  [80] = 80,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -599,554 +636,556 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(51);
+      if (eof) ADVANCE(49);
       ADVANCE_MAP(
-        '\n', 52,
-        '!', 55,
-        '(', 90,
-        ')', 93,
-        '*', 74,
-        ',', 92,
-        '.', 73,
-        '/', 100,
-        ':', 70,
-        '?', 76,
-        '\t', 71,
-        ' ', 71,
+        '\n', 50,
+        '!', 53,
+        '(', 88,
+        ')', 91,
+        '*', 72,
+        ',', 90,
+        '.', 71,
+        '/', 98,
+        ':', 68,
+        '?', 74,
+        '\t', 69,
+        ' ', 69,
       );
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(102);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(100);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(52);
-      if (lookahead == '(') ADVANCE(90);
-      if (lookahead == '/') ADVANCE(100);
+      if (lookahead == '\n') ADVANCE(50);
+      if (lookahead == '(') ADVANCE(88);
+      if (lookahead == '/') ADVANCE(98);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(71);
+          lookahead == ' ') ADVANCE(69);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(102);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(100);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(52);
-      if (lookahead == '/') ADVANCE(100);
+      if (lookahead == '\n') ADVANCE(50);
+      if (lookahead == '/') ADVANCE(98);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(71);
+          lookahead == ' ') ADVANCE(69);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(102);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(100);
       END_STATE();
     case 3:
-      if (lookahead == '\n') ADVANCE(52);
-      if (lookahead == '/') ADVANCE(79);
-      if (lookahead == '\\') ADVANCE(80);
+      if (lookahead == '\n') ADVANCE(50);
+      if (lookahead == '/') ADVANCE(77);
+      if (lookahead == '\\') ADVANCE(78);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(71);
-      if (lookahead != 0) ADVANCE(78);
+          lookahead == ' ') ADVANCE(69);
+      if (lookahead != 0) ADVANCE(76);
       END_STATE();
     case 4:
-      if (lookahead == '\r') ADVANCE(67);
-      if (lookahead == '\\') ADVANCE(59);
-      if (lookahead != 0) ADVANCE(66);
+      if (lookahead == '\r') ADVANCE(65);
+      if (lookahead == '\\') ADVANCE(57);
+      if (lookahead != 0) ADVANCE(64);
       END_STATE();
     case 5:
-      if (lookahead == ')') ADVANCE(93);
+      if (lookahead == ')') ADVANCE(91);
       if (lookahead == '.') ADVANCE(11);
       if (lookahead == '/') ADVANCE(6);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(71);
+          lookahead == ' ') ADVANCE(69);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(111);
       END_STATE();
     case 6:
       if (lookahead == '*') ADVANCE(9);
-      if (lookahead == '/') ADVANCE(66);
+      if (lookahead == '/') ADVANCE(64);
       END_STATE();
     case 7:
       if (lookahead == '*') ADVANCE(7);
-      if (lookahead == '/') ADVANCE(57);
+      if (lookahead == '/') ADVANCE(55);
       if (lookahead != 0) ADVANCE(9);
       END_STATE();
     case 8:
       if (lookahead == '*') ADVANCE(7);
-      if (lookahead != 0) ADVANCE(95);
+      if (lookahead != 0) ADVANCE(93);
       END_STATE();
     case 9:
       if (lookahead == '*') ADVANCE(7);
       if (lookahead != 0) ADVANCE(9);
       END_STATE();
     case 10:
-      if (lookahead == '.') ADVANCE(91);
+      if (lookahead == '.') ADVANCE(89);
       END_STATE();
     case 11:
       if (lookahead == '.') ADVANCE(10);
       END_STATE();
     case 12:
-      if (lookahead == 'c') ADVANCE(43);
+      if (lookahead == 'c') ADVANCE(41);
       END_STATE();
     case 13:
-      if (lookahead == 'd') ADVANCE(21);
-      if (lookahead == 'e') ADVANCE(42);
-      if (lookahead == 'i') ADVANCE(30);
-      if (lookahead == 'u') ADVANCE(44);
+      if (lookahead == 'd') ADVANCE(19);
+      if (lookahead == 'e') ADVANCE(40);
+      if (lookahead == 'i') ADVANCE(28);
+      if (lookahead == 'u') ADVANCE(42);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(13);
       END_STATE();
     case 14:
-      if (lookahead == 'd') ADVANCE(41);
+      if (lookahead == 'd') ADVANCE(39);
       END_STATE();
     case 15:
-      if (lookahead == 'd') ADVANCE(24);
+      if (lookahead == 'd') ADVANCE(22);
       END_STATE();
     case 16:
-      if (lookahead == 'd') ADVANCE(25);
-      if (lookahead == 'n') ADVANCE(18);
+      if (lookahead == 'd') ADVANCE(24);
       END_STATE();
     case 17:
-      if (lookahead == 'd') ADVANCE(26);
+      if (lookahead == 'd') ADVANCE(25);
       END_STATE();
     case 18:
       if (lookahead == 'd') ADVANCE(27);
       END_STATE();
     case 19:
-      if (lookahead == 'd') ADVANCE(28);
-      if (lookahead == 'n') ADVANCE(20);
+      if (lookahead == 'e') ADVANCE(29);
       END_STATE();
     case 20:
-      if (lookahead == 'd') ADVANCE(29);
-      END_STATE();
-    case 21:
-      if (lookahead == 'e') ADVANCE(31);
-      END_STATE();
-    case 22:
       if (lookahead == 'e') ADVANCE(110);
       END_STATE();
+    case 21:
+      if (lookahead == 'e') ADVANCE(87);
+      END_STATE();
+    case 22:
+      if (lookahead == 'e') ADVANCE(86);
+      END_STATE();
     case 23:
-      if (lookahead == 'e') ADVANCE(89);
+      if (lookahead == 'e') ADVANCE(32);
       END_STATE();
     case 24:
-      if (lookahead == 'e') ADVANCE(88);
-      END_STATE();
-    case 25:
       if (lookahead == 'e') ADVANCE(33);
       END_STATE();
-    case 26:
+    case 25:
       if (lookahead == 'e') ADVANCE(34);
       END_STATE();
-    case 27:
+    case 26:
       if (lookahead == 'e') ADVANCE(35);
       END_STATE();
-    case 28:
+    case 27:
       if (lookahead == 'e') ADVANCE(36);
       END_STATE();
-    case 29:
-      if (lookahead == 'e') ADVANCE(37);
-      END_STATE();
-    case 30:
-      if (lookahead == 'f') ADVANCE(16);
+    case 28:
+      if (lookahead == 'f') ADVANCE(103);
       if (lookahead == 'n') ADVANCE(12);
       END_STATE();
-    case 31:
-      if (lookahead == 'f') ADVANCE(39);
+    case 29:
+      if (lookahead == 'f') ADVANCE(37);
       END_STATE();
-    case 32:
+    case 30:
       if (lookahead == 'f') ADVANCE(107);
       END_STATE();
-    case 33:
-      if (lookahead == 'f') ADVANCE(105);
-      END_STATE();
-    case 34:
-      if (lookahead == 'f') ADVANCE(104);
-      END_STATE();
-    case 35:
+    case 31:
       if (lookahead == 'f') ADVANCE(106);
       END_STATE();
-    case 36:
+    case 32:
+      if (lookahead == 'f') ADVANCE(104);
+      END_STATE();
+    case 33:
+      if (lookahead == 'f') ADVANCE(102);
+      END_STATE();
+    case 34:
+      if (lookahead == 'f') ADVANCE(105);
+      END_STATE();
+    case 35:
       if (lookahead == 'f') ADVANCE(108);
       END_STATE();
-    case 37:
+    case 36:
       if (lookahead == 'f') ADVANCE(109);
       END_STATE();
+    case 37:
+      if (lookahead == 'i') ADVANCE(43);
+      END_STATE();
     case 38:
-      if (lookahead == 'f') ADVANCE(19);
+      if (lookahead == 'i') ADVANCE(30);
+      if (lookahead == 's') ADVANCE(20);
       END_STATE();
     case 39:
-      if (lookahead == 'i') ADVANCE(45);
+      if (lookahead == 'i') ADVANCE(31);
       END_STATE();
     case 40:
-      if (lookahead == 'i') ADVANCE(38);
-      if (lookahead == 's') ADVANCE(22);
-      END_STATE();
-    case 41:
-      if (lookahead == 'i') ADVANCE(32);
-      END_STATE();
-    case 42:
-      if (lookahead == 'l') ADVANCE(40);
+      if (lookahead == 'l') ADVANCE(38);
       if (lookahead == 'n') ADVANCE(14);
       END_STATE();
+    case 41:
+      if (lookahead == 'l') ADVANCE(44);
+      END_STATE();
+    case 42:
+      if (lookahead == 'n') ADVANCE(16);
+      END_STATE();
     case 43:
-      if (lookahead == 'l') ADVANCE(46);
+      if (lookahead == 'n') ADVANCE(21);
       END_STATE();
     case 44:
-      if (lookahead == 'n') ADVANCE(17);
-      END_STATE();
-    case 45:
-      if (lookahead == 'n') ADVANCE(23);
-      END_STATE();
-    case 46:
       if (lookahead == 'u') ADVANCE(15);
       END_STATE();
+    case 45:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(75);
+      END_STATE();
+    case 46:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(45);
+      END_STATE();
     case 47:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(77);
+      if (lookahead != 0 &&
+          lookahead != '*') ADVANCE(100);
       END_STATE();
     case 48:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(47);
-      END_STATE();
-    case 49:
-      if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(102);
-      END_STATE();
-    case 50:
-      if (eof) ADVANCE(51);
+      if (eof) ADVANCE(49);
       ADVANCE_MAP(
-        '\n', 52,
-        '!', 56,
-        '"', 81,
+        '\n', 50,
+        '!', 54,
+        '"', 79,
         '#', 13,
-        ')', 93,
-        '*', 74,
-        ',', 92,
-        '.', 73,
+        ')', 91,
+        '*', 72,
+        ',', 90,
+        '.', 71,
         '/', 6,
-        ':', 70,
-        '?', 76,
-        '\t', 71,
-        ' ', 71,
+        ':', 68,
+        '?', 74,
+        '\t', 69,
+        ' ', 69,
       );
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       END_STATE();
-    case 51:
+    case 49:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 52:
+    case 50:
       ACCEPT_TOKEN(aux_sym__line_token1);
+      END_STATE();
+    case 51:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '\r') ADVANCE(53);
+      if (lookahead == '/') ADVANCE(52);
+      if (lookahead == '\\') ADVANCE(51);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(53);
+      END_STATE();
+    case 52:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '*') ADVANCE(54);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(53);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '\r') ADVANCE(55);
-      if (lookahead == '/') ADVANCE(54);
-      if (lookahead == '\\') ADVANCE(53);
+      if (lookahead == '/') ADVANCE(52);
+      if (lookahead == '\\') ADVANCE(51);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(55);
+          lookahead != '\n') ADVANCE(53);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '*') ADVANCE(56);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(55);
+          lookahead != '\n') ADVANCE(54);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '/') ADVANCE(54);
-      if (lookahead == '\\') ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(55);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(56);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\n') ADVANCE(64);
+      if (lookahead == '/') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(97);
+      if (lookahead != 0) ADVANCE(62);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\r') ADVANCE(65);
+      if (lookahead == '\\') ADVANCE(57);
+      if (lookahead != 0) ADVANCE(64);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\n') ADVANCE(66);
-      if (lookahead == '/') ADVANCE(63);
-      if (lookahead == '\\') ADVANCE(99);
-      if (lookahead != 0) ADVANCE(64);
+      if (lookahead == '\r') ADVANCE(63);
+      if (lookahead == '/') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(58);
+      if (lookahead != 0) ADVANCE(62);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(67);
+      if (lookahead == '\r') ADVANCE(66);
       if (lookahead == '\\') ADVANCE(59);
-      if (lookahead != 0) ADVANCE(66);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(64);
+      if (lookahead != 0) ADVANCE(60);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(65);
-      if (lookahead == '/') ADVANCE(63);
-      if (lookahead == '\\') ADVANCE(60);
-      if (lookahead != 0) ADVANCE(64);
+      if (lookahead == '"') ADVANCE(64);
+      if (lookahead == '\\') ADVANCE(80);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(60);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(68);
-      if (lookahead == '\\') ADVANCE(61);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(66);
-      if (lookahead != 0) ADVANCE(62);
+      if (lookahead == '*') ADVANCE(64);
+      if (lookahead == '\\') ADVANCE(94);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(62);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '"') ADVANCE(66);
-      if (lookahead == '\\') ADVANCE(82);
+      if (lookahead == '/') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(97);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(62);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '*') ADVANCE(66);
-      if (lookahead == '\\') ADVANCE(96);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(64);
+      if (lookahead == '/') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(97);
+      if (lookahead != 0) ADVANCE(62);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '/') ADVANCE(63);
-      if (lookahead == '\\') ADVANCE(99);
+      if (lookahead == '\\') ADVANCE(4);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(64);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '/') ADVANCE(63);
-      if (lookahead == '\\') ADVANCE(99);
+      if (lookahead == '\\') ADVANCE(4);
       if (lookahead != 0) ADVANCE(64);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(4);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(66);
+      if (lookahead == '\\') ADVANCE(80);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(64);
+      if (lookahead != 0) ADVANCE(60);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(4);
-      if (lookahead != 0) ADVANCE(66);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(85);
       END_STATE();
     case 68:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(82);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(66);
-      if (lookahead != 0) ADVANCE(62);
-      END_STATE();
-    case 69:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(87);
-      END_STATE();
-    case 70:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 71:
+    case 69:
       ACCEPT_TOKEN(aux_sym_resource_token1);
       END_STATE();
-    case 72:
+    case 70:
       ACCEPT_TOKEN(aux_sym_resource_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(87);
+          lookahead != '"') ADVANCE(85);
       END_STATE();
-    case 73:
+    case 71:
       ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
-    case 74:
+    case 72:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 75:
+    case 73:
       ACCEPT_TOKEN(sym_component);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       END_STATE();
-    case 76:
+    case 74:
       ACCEPT_TOKEN(sym_any_component);
       END_STATE();
-    case 77:
+    case 75:
       ACCEPT_TOKEN(sym_escape_sequence);
       END_STATE();
-    case 78:
+    case 76:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       END_STATE();
-    case 79:
+    case 77:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       if (lookahead == '*') ADVANCE(9);
-      if (lookahead == '/') ADVANCE(66);
+      if (lookahead == '/') ADVANCE(64);
       END_STATE();
-    case 80:
+    case 78:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == ' ' ||
           lookahead == '\\' ||
-          lookahead == 'n') ADVANCE(77);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(48);
+          lookahead == 'n') ADVANCE(75);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(46);
+      END_STATE();
+    case 79:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '\r') ADVANCE(66);
+      if (lookahead == '\\') ADVANCE(59);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(64);
+      if (lookahead != 0) ADVANCE(60);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '*') ADVANCE(83);
+      if (lookahead == '/') ADVANCE(60);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(85);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '\r') ADVANCE(68);
-      if (lookahead == '\\') ADVANCE(61);
+      if (lookahead == '*') ADVANCE(82);
+      if (lookahead == '/') ADVANCE(67);
       if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(66);
-      if (lookahead != 0) ADVANCE(62);
+          lookahead == '"') ADVANCE(9);
+      if (lookahead != 0) ADVANCE(83);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(85);
-      if (lookahead == '/') ADVANCE(62);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(87);
+      if (lookahead == '*') ADVANCE(82);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(9);
+      if (lookahead != 0) ADVANCE(83);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(84);
-      if (lookahead == '/') ADVANCE(69);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(9);
-      if (lookahead != 0) ADVANCE(85);
-      END_STATE();
-    case 85:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(84);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(9);
-      if (lookahead != 0) ADVANCE(85);
-      END_STATE();
-    case 86:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '/') ADVANCE(83);
+      if (lookahead == '/') ADVANCE(81);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(72);
+          lookahead == ' ') ADVANCE(70);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(87);
+          lookahead != '"') ADVANCE(85);
       END_STATE();
-    case 87:
+    case 85:
       ACCEPT_TOKEN(aux_sym_string_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(87);
+          lookahead != '"') ADVANCE(85);
       END_STATE();
-    case 88:
+    case 86:
       ACCEPT_TOKEN(aux_sym_include_directive_token1);
       END_STATE();
-    case 89:
+    case 87:
       ACCEPT_TOKEN(aux_sym_define_directive_token1);
       END_STATE();
-    case 90:
+    case 88:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
-    case 91:
+    case 89:
       ACCEPT_TOKEN(anon_sym_DOT_DOT_DOT);
       END_STATE();
-    case 92:
+    case 90:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 93:
+    case 91:
       ACCEPT_TOKEN(anon_sym_RPAREN);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\n') ADVANCE(9);
+      if (lookahead == '*') ADVANCE(92);
+      if (lookahead == '/') ADVANCE(55);
+      if (lookahead == '\\') ADVANCE(96);
+      if (lookahead != 0) ADVANCE(93);
+      END_STATE();
+    case 93:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\n') ADVANCE(9);
+      if (lookahead == '*') ADVANCE(92);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(96);
+      if (lookahead != 0) ADVANCE(93);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(9);
-      if (lookahead == '*') ADVANCE(94);
-      if (lookahead == '/') ADVANCE(57);
-      if (lookahead == '\\') ADVANCE(98);
-      if (lookahead != 0) ADVANCE(95);
+      if (lookahead == '\n') ADVANCE(64);
+      if (lookahead == '\r') ADVANCE(56);
+      if (lookahead == '/') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(58);
+      if (lookahead != 0) ADVANCE(62);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(9);
-      if (lookahead == '*') ADVANCE(94);
-      if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '\\') ADVANCE(98);
-      if (lookahead != 0) ADVANCE(95);
+      if (lookahead == '\r') ADVANCE(101);
+      if (lookahead == '/') ADVANCE(47);
+      if (lookahead == '\\') ADVANCE(95);
+      if (lookahead != 0) ADVANCE(100);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(66);
-      if (lookahead == '\r') ADVANCE(58);
-      if (lookahead == '/') ADVANCE(63);
-      if (lookahead == '\\') ADVANCE(60);
-      if (lookahead != 0) ADVANCE(64);
+      if (lookahead == '\r') ADVANCE(99);
+      if (lookahead == '*') ADVANCE(92);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(96);
+      if (lookahead != 0) ADVANCE(93);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(103);
-      if (lookahead == '/') ADVANCE(49);
-      if (lookahead == '\\') ADVANCE(97);
-      if (lookahead != 0) ADVANCE(102);
+      if (lookahead == '\r') ADVANCE(63);
+      if (lookahead == '/') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(58);
+      if (lookahead != 0) ADVANCE(62);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(101);
-      if (lookahead == '*') ADVANCE(94);
-      if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '\\') ADVANCE(98);
-      if (lookahead != 0) ADVANCE(95);
+      if (lookahead == '*') ADVANCE(93);
+      if (lookahead == '/') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(95);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(100);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(65);
-      if (lookahead == '/') ADVANCE(63);
-      if (lookahead == '\\') ADVANCE(60);
-      if (lookahead != 0) ADVANCE(64);
+      if (lookahead == '*') ADVANCE(92);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(96);
+      if (lookahead != 0) ADVANCE(93);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(95);
-      if (lookahead == '/') ADVANCE(63);
-      if (lookahead == '\\') ADVANCE(97);
+      if (lookahead == '/') ADVANCE(47);
+      if (lookahead == '\\') ADVANCE(95);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(102);
+          lookahead != '\n') ADVANCE(100);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(94);
-      if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '\\') ADVANCE(98);
-      if (lookahead != 0) ADVANCE(95);
+      if (lookahead == '/') ADVANCE(47);
+      if (lookahead == '\\') ADVANCE(95);
+      if (lookahead != 0) ADVANCE(100);
       END_STATE();
     case 102:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '/') ADVANCE(49);
-      if (lookahead == '\\') ADVANCE(97);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(102);
-      END_STATE();
-    case 103:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '/') ADVANCE(49);
-      if (lookahead == '\\') ADVANCE(97);
-      if (lookahead != 0) ADVANCE(102);
-      END_STATE();
-    case 104:
       ACCEPT_TOKEN(aux_sym_undef_directive_token1);
       END_STATE();
-    case 105:
+    case 103:
+      ACCEPT_TOKEN(aux_sym_if_directive_token1);
+      if (lookahead == 'd') ADVANCE(23);
+      if (lookahead == 'n') ADVANCE(17);
+      END_STATE();
+    case 104:
       ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
       END_STATE();
-    case 106:
+    case 105:
       ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
       END_STATE();
+    case 106:
+      ACCEPT_TOKEN(aux_sym__if_directive_body_token1);
+      END_STATE();
     case 107:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token3);
+      ACCEPT_TOKEN(aux_sym_elif_directive_token1);
+      if (lookahead == 'd') ADVANCE(26);
+      if (lookahead == 'n') ADVANCE(18);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(aux_sym_elifdef_directive_token1);
@@ -1171,79 +1210,86 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 50},
-  [2] = {.lex_state = 50},
-  [3] = {.lex_state = 50},
-  [4] = {.lex_state = 50},
-  [5] = {.lex_state = 50},
-  [6] = {.lex_state = 50},
-  [7] = {.lex_state = 50},
-  [8] = {.lex_state = 50},
-  [9] = {.lex_state = 50},
-  [10] = {.lex_state = 50},
-  [11] = {.lex_state = 50},
-  [12] = {.lex_state = 50},
-  [13] = {.lex_state = 50},
-  [14] = {.lex_state = 50},
-  [15] = {.lex_state = 50},
-  [16] = {.lex_state = 50},
-  [17] = {.lex_state = 50},
-  [18] = {.lex_state = 50},
-  [19] = {.lex_state = 3},
-  [20] = {.lex_state = 50},
+  [1] = {.lex_state = 48},
+  [2] = {.lex_state = 48},
+  [3] = {.lex_state = 48},
+  [4] = {.lex_state = 48},
+  [5] = {.lex_state = 48},
+  [6] = {.lex_state = 48},
+  [7] = {.lex_state = 48},
+  [8] = {.lex_state = 48},
+  [9] = {.lex_state = 48},
+  [10] = {.lex_state = 48},
+  [11] = {.lex_state = 48},
+  [12] = {.lex_state = 48},
+  [13] = {.lex_state = 48},
+  [14] = {.lex_state = 48},
+  [15] = {.lex_state = 48},
+  [16] = {.lex_state = 48},
+  [17] = {.lex_state = 48},
+  [18] = {.lex_state = 48},
+  [19] = {.lex_state = 48},
+  [20] = {.lex_state = 48},
   [21] = {.lex_state = 3},
-  [22] = {.lex_state = 50},
-  [23] = {.lex_state = 50},
-  [24] = {.lex_state = 50},
-  [25] = {.lex_state = 3},
-  [26] = {.lex_state = 50},
-  [27] = {.lex_state = 3},
-  [28] = {.lex_state = 1},
-  [29] = {.lex_state = 50},
-  [30] = {.lex_state = 5},
-  [31] = {.lex_state = 50},
-  [32] = {.lex_state = 50},
-  [33] = {.lex_state = 50},
-  [34] = {.lex_state = 3},
-  [35] = {.lex_state = 50},
-  [36] = {.lex_state = 50},
-  [37] = {.lex_state = 2},
-  [38] = {.lex_state = 50},
-  [39] = {.lex_state = 2},
-  [40] = {.lex_state = 5},
-  [41] = {.lex_state = 2},
+  [22] = {.lex_state = 48},
+  [23] = {.lex_state = 3},
+  [24] = {.lex_state = 48},
+  [25] = {.lex_state = 48},
+  [26] = {.lex_state = 48},
+  [27] = {.lex_state = 48},
+  [28] = {.lex_state = 3},
+  [29] = {.lex_state = 1},
+  [30] = {.lex_state = 48},
+  [31] = {.lex_state = 3},
+  [32] = {.lex_state = 48},
+  [33] = {.lex_state = 5},
+  [34] = {.lex_state = 48},
+  [35] = {.lex_state = 48},
+  [36] = {.lex_state = 48},
+  [37] = {.lex_state = 48},
+  [38] = {.lex_state = 48},
+  [39] = {.lex_state = 3},
+  [40] = {.lex_state = 48},
+  [41] = {.lex_state = 48},
   [42] = {.lex_state = 2},
-  [43] = {.lex_state = 50},
-  [44] = {.lex_state = 0},
-  [45] = {.lex_state = 0},
-  [46] = {.lex_state = 50},
-  [47] = {.lex_state = 5},
-  [48] = {.lex_state = 86},
-  [49] = {.lex_state = 0},
-  [50] = {.lex_state = 5},
-  [51] = {.lex_state = 50},
+  [43] = {.lex_state = 5},
+  [44] = {.lex_state = 2},
+  [45] = {.lex_state = 2},
+  [46] = {.lex_state = 2},
+  [47] = {.lex_state = 84},
+  [48] = {.lex_state = 0},
+  [49] = {.lex_state = 48},
+  [50] = {.lex_state = 48},
+  [51] = {.lex_state = 5},
   [52] = {.lex_state = 0},
   [53] = {.lex_state = 0},
   [54] = {.lex_state = 5},
-  [55] = {.lex_state = 0},
-  [56] = {.lex_state = 50},
-  [57] = {.lex_state = 0},
-  [58] = {.lex_state = 0},
-  [59] = {.lex_state = 50},
+  [55] = {.lex_state = 2},
+  [56] = {.lex_state = 0},
+  [57] = {.lex_state = 2},
+  [58] = {.lex_state = 5},
+  [59] = {.lex_state = 48},
   [60] = {.lex_state = 0},
   [61] = {.lex_state = 0},
-  [62] = {.lex_state = 50},
+  [62] = {.lex_state = 0},
   [63] = {.lex_state = 0},
-  [64] = {.lex_state = 0},
-  [65] = {.lex_state = 0},
+  [64] = {.lex_state = 48},
+  [65] = {.lex_state = 5},
   [66] = {.lex_state = 0},
-  [67] = {.lex_state = 5},
+  [67] = {.lex_state = 48},
   [68] = {.lex_state = 0},
   [69] = {.lex_state = 0},
   [70] = {.lex_state = 0},
-  [71] = {.lex_state = 50},
+  [71] = {.lex_state = 0},
   [72] = {.lex_state = 0},
   [73] = {.lex_state = 0},
+  [74] = {.lex_state = 0},
+  [75] = {.lex_state = 0},
+  [76] = {.lex_state = 0},
+  [77] = {.lex_state = 48},
+  [78] = {.lex_state = 0},
+  [79] = {.lex_state = 0},
+  [80] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1264,20 +1310,21 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_expansion] = ACTIONS(1),
   },
   [1] = {
-    [sym_resources] = STATE(68),
-    [sym__line] = STATE(10),
-    [sym__statement] = STATE(65),
-    [sym_resource] = STATE(65),
-    [sym_components] = STATE(51),
-    [sym_binding] = STATE(12),
-    [sym_include_directive] = STATE(65),
-    [sym_define_directive] = STATE(65),
-    [sym_define_function_directive] = STATE(65),
-    [sym_undef_directive] = STATE(65),
-    [sym_ifdef_directive] = STATE(65),
-    [aux_sym_resources_repeat1] = STATE(7),
-    [aux_sym_components_repeat1] = STATE(12),
-    [aux_sym_components_repeat2] = STATE(31),
+    [sym_resources] = STATE(69),
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [aux_sym_resources_repeat1] = STATE(10),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
     [ts_builtin_sym_end] = ACTIONS(5),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
@@ -1290,26 +1337,30 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
     [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
   },
   [2] = {
-    [sym__line] = STATE(10),
-    [sym__statement] = STATE(65),
-    [sym_resource] = STATE(65),
-    [sym_components] = STATE(51),
-    [sym_binding] = STATE(12),
-    [sym_include_directive] = STATE(65),
-    [sym_define_directive] = STATE(65),
-    [sym_define_function_directive] = STATE(65),
-    [sym_undef_directive] = STATE(65),
-    [sym_ifdef_directive] = STATE(65),
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [sym__if_directive_body] = STATE(63),
+    [sym_elif_directive] = STATE(26),
     [sym_elifdef_directive] = STATE(26),
-    [sym_else_directive] = STATE(59),
+    [sym_else_directive] = STATE(49),
     [aux_sym_resources_repeat1] = STATE(4),
-    [aux_sym_components_repeat1] = STATE(12),
-    [aux_sym_components_repeat2] = STATE(31),
-    [aux_sym_ifdef_directive_repeat1] = STATE(13),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
+    [aux_sym__if_directive_body_repeat1] = STATE(16),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1321,30 +1372,35 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
     [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(25),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(27),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(27),
-    [aux_sym_else_directive_token1] = ACTIONS(29),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(27),
+    [aux_sym_elif_directive_token1] = ACTIONS(29),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(31),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(31),
+    [aux_sym_else_directive_token1] = ACTIONS(33),
   },
   [3] = {
-    [sym__line] = STATE(10),
-    [sym__statement] = STATE(65),
-    [sym_resource] = STATE(65),
-    [sym_components] = STATE(51),
-    [sym_binding] = STATE(12),
-    [sym_include_directive] = STATE(65),
-    [sym_define_directive] = STATE(65),
-    [sym_define_function_directive] = STATE(65),
-    [sym_undef_directive] = STATE(65),
-    [sym_ifdef_directive] = STATE(65),
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [sym__if_directive_body] = STATE(52),
+    [sym_elif_directive] = STATE(26),
     [sym_elifdef_directive] = STATE(26),
-    [sym_else_directive] = STATE(46),
-    [aux_sym_resources_repeat1] = STATE(2),
-    [aux_sym_components_repeat1] = STATE(12),
-    [aux_sym_components_repeat2] = STATE(31),
-    [aux_sym_ifdef_directive_repeat1] = STATE(14),
+    [sym_else_directive] = STATE(49),
+    [aux_sym_resources_repeat1] = STATE(4),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
+    [aux_sym__if_directive_body_repeat1] = STATE(16),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1356,92 +1412,105 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
     [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(31),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(27),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(27),
-    [aux_sym_else_directive_token1] = ACTIONS(29),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(35),
+    [aux_sym_elif_directive_token1] = ACTIONS(29),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(31),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(31),
+    [aux_sym_else_directive_token1] = ACTIONS(33),
   },
   [4] = {
-    [sym__line] = STATE(10),
-    [sym__statement] = STATE(65),
-    [sym_resource] = STATE(65),
-    [sym_components] = STATE(51),
-    [sym_binding] = STATE(12),
-    [sym_include_directive] = STATE(65),
-    [sym_define_directive] = STATE(65),
-    [sym_define_function_directive] = STATE(65),
-    [sym_undef_directive] = STATE(65),
-    [sym_ifdef_directive] = STATE(65),
-    [aux_sym_resources_repeat1] = STATE(4),
-    [aux_sym_components_repeat1] = STATE(12),
-    [aux_sym_components_repeat2] = STATE(31),
-    [ts_builtin_sym_end] = ACTIONS(33),
-    [aux_sym__line_token1] = ACTIONS(35),
-    [sym_comment] = ACTIONS(38),
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [sym_elif_directive] = STATE(26),
+    [sym_elifdef_directive] = STATE(26),
+    [sym_else_directive] = STATE(64),
+    [aux_sym_resources_repeat1] = STATE(5),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
+    [aux_sym__if_directive_body_repeat1] = STATE(15),
+    [aux_sym__line_token1] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(41),
-    [anon_sym_STAR] = ACTIONS(41),
-    [sym_component] = ACTIONS(44),
-    [sym_any_component] = ACTIONS(47),
-    [aux_sym_include_directive_token1] = ACTIONS(50),
-    [aux_sym_define_directive_token1] = ACTIONS(53),
-    [aux_sym_undef_directive_token1] = ACTIONS(56),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(59),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(59),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(33),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(33),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(33),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(37),
+    [aux_sym_elif_directive_token1] = ACTIONS(29),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(31),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(31),
     [aux_sym_else_directive_token1] = ACTIONS(33),
   },
   [5] = {
-    [sym__line] = STATE(10),
-    [sym__statement] = STATE(65),
-    [sym_resource] = STATE(65),
-    [sym_components] = STATE(51),
-    [sym_binding] = STATE(12),
-    [sym_include_directive] = STATE(65),
-    [sym_define_directive] = STATE(65),
-    [sym_define_function_directive] = STATE(65),
-    [sym_undef_directive] = STATE(65),
-    [sym_ifdef_directive] = STATE(65),
-    [aux_sym_resources_repeat1] = STATE(6),
-    [aux_sym_components_repeat1] = STATE(12),
-    [aux_sym_components_repeat2] = STATE(31),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [aux_sym_resources_repeat1] = STATE(5),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
+    [ts_builtin_sym_end] = ACTIONS(39),
+    [aux_sym__line_token1] = ACTIONS(41),
+    [sym_comment] = ACTIONS(44),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(11),
-    [sym_component] = ACTIONS(13),
-    [sym_any_component] = ACTIONS(15),
-    [aux_sym_include_directive_token1] = ACTIONS(17),
-    [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(62),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(62),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(62),
-    [aux_sym_else_directive_token1] = ACTIONS(62),
+    [anon_sym_DOT] = ACTIONS(47),
+    [anon_sym_STAR] = ACTIONS(47),
+    [sym_component] = ACTIONS(50),
+    [sym_any_component] = ACTIONS(53),
+    [aux_sym_include_directive_token1] = ACTIONS(56),
+    [aux_sym_define_directive_token1] = ACTIONS(59),
+    [aux_sym_undef_directive_token1] = ACTIONS(62),
+    [aux_sym_if_directive_token1] = ACTIONS(65),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(68),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(68),
+    [aux_sym__if_directive_body_token1] = ACTIONS(39),
+    [aux_sym_elif_directive_token1] = ACTIONS(71),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(39),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(39),
+    [aux_sym_else_directive_token1] = ACTIONS(39),
   },
   [6] = {
-    [sym__line] = STATE(10),
-    [sym__statement] = STATE(65),
-    [sym_resource] = STATE(65),
-    [sym_components] = STATE(51),
-    [sym_binding] = STATE(12),
-    [sym_include_directive] = STATE(65),
-    [sym_define_directive] = STATE(65),
-    [sym_define_function_directive] = STATE(65),
-    [sym_undef_directive] = STATE(65),
-    [sym_ifdef_directive] = STATE(65),
-    [aux_sym_resources_repeat1] = STATE(4),
-    [aux_sym_components_repeat1] = STATE(12),
-    [aux_sym_components_repeat2] = STATE(31),
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [aux_sym_resources_repeat1] = STATE(8),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1453,28 +1522,30 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
     [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(64),
-    [aux_sym_elifdef_directive_token1] = ACTIONS(64),
-    [aux_sym_elifdef_directive_token2] = ACTIONS(64),
-    [aux_sym_else_directive_token1] = ACTIONS(64),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(73),
+    [aux_sym_elif_directive_token1] = ACTIONS(75),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(73),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(73),
+    [aux_sym_else_directive_token1] = ACTIONS(73),
   },
   [7] = {
-    [sym__line] = STATE(10),
-    [sym__statement] = STATE(65),
-    [sym_resource] = STATE(65),
-    [sym_components] = STATE(51),
-    [sym_binding] = STATE(12),
-    [sym_include_directive] = STATE(65),
-    [sym_define_directive] = STATE(65),
-    [sym_define_function_directive] = STATE(65),
-    [sym_undef_directive] = STATE(65),
-    [sym_ifdef_directive] = STATE(65),
-    [aux_sym_resources_repeat1] = STATE(4),
-    [aux_sym_components_repeat1] = STATE(12),
-    [aux_sym_components_repeat2] = STATE(31),
-    [ts_builtin_sym_end] = ACTIONS(66),
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [aux_sym_resources_repeat1] = STATE(9),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1486,23 +1557,30 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
     [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(77),
+    [aux_sym_elif_directive_token1] = ACTIONS(79),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(77),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(77),
+    [aux_sym_else_directive_token1] = ACTIONS(77),
   },
   [8] = {
-    [sym__line] = STATE(10),
-    [sym__statement] = STATE(65),
-    [sym_resource] = STATE(65),
-    [sym_components] = STATE(51),
-    [sym_binding] = STATE(12),
-    [sym_include_directive] = STATE(65),
-    [sym_define_directive] = STATE(65),
-    [sym_define_function_directive] = STATE(65),
-    [sym_undef_directive] = STATE(65),
-    [sym_ifdef_directive] = STATE(65),
-    [aux_sym_resources_repeat1] = STATE(9),
-    [aux_sym_components_repeat1] = STATE(12),
-    [aux_sym_components_repeat2] = STATE(31),
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [aux_sym_resources_repeat1] = STATE(5),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1514,24 +1592,30 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
     [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(68),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(81),
+    [aux_sym_elif_directive_token1] = ACTIONS(83),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(81),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(81),
+    [aux_sym_else_directive_token1] = ACTIONS(81),
   },
   [9] = {
-    [sym__line] = STATE(10),
-    [sym__statement] = STATE(65),
-    [sym_resource] = STATE(65),
-    [sym_components] = STATE(51),
-    [sym_binding] = STATE(12),
-    [sym_include_directive] = STATE(65),
-    [sym_define_directive] = STATE(65),
-    [sym_define_function_directive] = STATE(65),
-    [sym_undef_directive] = STATE(65),
-    [sym_ifdef_directive] = STATE(65),
-    [aux_sym_resources_repeat1] = STATE(4),
-    [aux_sym_components_repeat1] = STATE(12),
-    [aux_sym_components_repeat2] = STATE(31),
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [aux_sym_resources_repeat1] = STATE(5),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1543,18 +1627,119 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
     [aux_sym_undef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(70),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(85),
+    [aux_sym_elif_directive_token1] = ACTIONS(87),
+    [aux_sym_elifdef_directive_token1] = ACTIONS(85),
+    [aux_sym_elifdef_directive_token2] = ACTIONS(85),
+    [aux_sym_else_directive_token1] = ACTIONS(85),
+  },
+  [10] = {
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [aux_sym_resources_repeat1] = STATE(5),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
+    [ts_builtin_sym_end] = ACTIONS(89),
+    [aux_sym__line_token1] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
+    [sym_preprocessor_comment] = ACTIONS(3),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+  },
+  [11] = {
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [aux_sym_resources_repeat1] = STATE(12),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
+    [aux_sym__line_token1] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
+    [sym_preprocessor_comment] = ACTIONS(3),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(91),
+  },
+  [12] = {
+    [sym__line] = STATE(13),
+    [sym__statement] = STATE(48),
+    [sym_resource] = STATE(48),
+    [sym_components] = STATE(50),
+    [sym_binding] = STATE(18),
+    [sym_include_directive] = STATE(48),
+    [sym_define_directive] = STATE(48),
+    [sym_define_function_directive] = STATE(48),
+    [sym_undef_directive] = STATE(48),
+    [sym_if_directive] = STATE(48),
+    [sym_ifdef_directive] = STATE(48),
+    [aux_sym_resources_repeat1] = STATE(5),
+    [aux_sym_components_repeat1] = STATE(18),
+    [aux_sym_components_repeat2] = STATE(37),
+    [aux_sym__line_token1] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
+    [sym_preprocessor_comment] = ACTIONS(3),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_if_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(25),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(25),
+    [aux_sym__if_directive_body_token1] = ACTIONS(93),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 2,
+  [0] = 3,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(72), 16,
+    ACTIONS(97), 2,
+      aux_sym_if_directive_token1,
+      aux_sym_elif_directive_token1,
+    ACTIONS(95), 16,
       ts_builtin_sym_end,
       aux_sym__line_token1,
       sym_comment,
@@ -1567,15 +1752,18 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_undef_directive_token1,
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
-      aux_sym_ifdef_directive_token3,
+      aux_sym__if_directive_body_token1,
       aux_sym_elifdef_directive_token1,
       aux_sym_elifdef_directive_token2,
       aux_sym_else_directive_token1,
-  [23] = 2,
+  [27] = 3,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(74), 16,
+    ACTIONS(101), 2,
+      aux_sym_if_directive_token1,
+      aux_sym_elif_directive_token1,
+    ACTIONS(99), 16,
       ts_builtin_sym_end,
       aux_sym__line_token1,
       sym_comment,
@@ -1588,16 +1776,73 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_undef_directive_token1,
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
-      aux_sym_ifdef_directive_token3,
+      aux_sym__if_directive_body_token1,
       aux_sym_elifdef_directive_token1,
       aux_sym_elifdef_directive_token2,
       aux_sym_else_directive_token1,
-  [46] = 6,
+  [54] = 8,
+    ACTIONS(29), 1,
+      aux_sym_elif_directive_token1,
+    ACTIONS(33), 1,
+      aux_sym_else_directive_token1,
+    ACTIONS(103), 1,
+      aux_sym__if_directive_body_token1,
+    STATE(17), 1,
+      aux_sym__if_directive_body_repeat1,
+    STATE(77), 1,
+      sym_else_directive,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(31), 2,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
+    STATE(26), 2,
+      sym_elif_directive,
+      sym_elifdef_directive,
+  [82] = 8,
+    ACTIONS(29), 1,
+      aux_sym_elif_directive_token1,
+    ACTIONS(33), 1,
+      aux_sym_else_directive_token1,
+    ACTIONS(105), 1,
+      aux_sym__if_directive_body_token1,
+    STATE(17), 1,
+      aux_sym__if_directive_body_repeat1,
+    STATE(67), 1,
+      sym_else_directive,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(31), 2,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
+    STATE(26), 2,
+      sym_elif_directive,
+      sym_elifdef_directive,
+  [110] = 6,
+    ACTIONS(109), 1,
+      aux_sym_elif_directive_token1,
+    STATE(17), 1,
+      aux_sym__if_directive_body_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(107), 2,
+      aux_sym__if_directive_body_token1,
+      aux_sym_else_directive_token1,
+    ACTIONS(112), 2,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
+    STATE(26), 2,
+      sym_elif_directive,
+      sym_elifdef_directive,
+  [133] = 6,
     ACTIONS(15), 1,
       sym_any_component,
-    ACTIONS(76), 1,
+    ACTIONS(115), 1,
       sym_component,
-    STATE(33), 1,
+    STATE(38), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1605,522 +1850,500 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(16), 2,
+    STATE(19), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [68] = 7,
-    ACTIONS(29), 1,
-      aux_sym_else_directive_token1,
-    ACTIONS(78), 1,
-      aux_sym_ifdef_directive_token3,
-    STATE(17), 1,
-      aux_sym_ifdef_directive_repeat1,
-    STATE(26), 1,
-      sym_elifdef_directive,
-    STATE(71), 1,
-      sym_else_directive,
+  [155] = 4,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(27), 2,
-      aux_sym_elifdef_directive_token1,
-      aux_sym_elifdef_directive_token2,
-  [92] = 7,
-    ACTIONS(29), 1,
-      aux_sym_else_directive_token1,
-    ACTIONS(80), 1,
-      aux_sym_ifdef_directive_token3,
-    STATE(17), 1,
-      aux_sym_ifdef_directive_repeat1,
-    STATE(26), 1,
-      sym_elifdef_directive,
-    STATE(62), 1,
-      sym_else_directive,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(27), 2,
-      aux_sym_elifdef_directive_token1,
-      aux_sym_elifdef_directive_token2,
-  [116] = 4,
+    ACTIONS(117), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    ACTIONS(120), 2,
+      sym_component,
+      sym_any_component,
+    STATE(19), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [172] = 4,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    ACTIONS(82), 2,
+    ACTIONS(122), 2,
       sym_component,
       sym_any_component,
-    STATE(16), 2,
+    STATE(19), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [133] = 4,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(84), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    ACTIONS(87), 2,
-      sym_component,
-      sym_any_component,
-    STATE(16), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [150] = 5,
-    STATE(17), 1,
-      aux_sym_ifdef_directive_repeat1,
-    STATE(26), 1,
-      sym_elifdef_directive,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(89), 2,
-      aux_sym_ifdef_directive_token3,
-      aux_sym_else_directive_token1,
-    ACTIONS(91), 2,
-      aux_sym_elifdef_directive_token1,
-      aux_sym_elifdef_directive_token2,
-  [169] = 4,
-    ACTIONS(94), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    STATE(15), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [185] = 7,
+  [189] = 7,
     ACTIONS(3), 1,
       sym_preprocessor_comment,
-    ACTIONS(96), 1,
+    ACTIONS(124), 1,
       aux_sym_resource_token1,
-    ACTIONS(98), 1,
-      sym_escape_sequence,
-    ACTIONS(100), 1,
-      aux_sym_resource_value_token1,
-    STATE(21), 1,
-      aux_sym_resource_repeat1,
-    STATE(25), 1,
-      aux_sym_resource_value_repeat1,
-    STATE(45), 1,
-      sym_resource_value,
-  [207] = 4,
-    ACTIONS(102), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    STATE(15), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [223] = 7,
-    ACTIONS(3), 1,
-      sym_preprocessor_comment,
-    ACTIONS(98), 1,
-      sym_escape_sequence,
-    ACTIONS(100), 1,
-      aux_sym_resource_value_token1,
-    ACTIONS(104), 1,
-      aux_sym_resource_token1,
-    STATE(25), 1,
-      aux_sym_resource_value_repeat1,
-    STATE(34), 1,
-      aux_sym_resource_repeat1,
-    STATE(49), 1,
-      sym_resource_value,
-  [245] = 4,
-    ACTIONS(106), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    STATE(15), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [261] = 3,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    STATE(15), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [274] = 2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(108), 4,
-      anon_sym_DOT,
-      anon_sym_STAR,
-      sym_component,
-      sym_any_component,
-  [285] = 5,
-    ACTIONS(110), 1,
-      aux_sym__line_token1,
-    ACTIONS(112), 1,
-      sym_escape_sequence,
-    ACTIONS(114), 1,
-      aux_sym_resource_value_token1,
-    STATE(27), 1,
-      aux_sym_resource_value_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [302] = 2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(116), 4,
-      aux_sym_ifdef_directive_token3,
-      aux_sym_elifdef_directive_token1,
-      aux_sym_elifdef_directive_token2,
-      aux_sym_else_directive_token1,
-  [313] = 5,
-    ACTIONS(118), 1,
-      aux_sym__line_token1,
-    ACTIONS(120), 1,
-      sym_escape_sequence,
-    ACTIONS(123), 1,
-      aux_sym_resource_value_token1,
-    STATE(27), 1,
-      aux_sym_resource_value_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [330] = 5,
     ACTIONS(126), 1,
-      aux_sym__line_token1,
+      sym_escape_sequence,
     ACTIONS(128), 1,
-      anon_sym_LPAREN,
+      aux_sym_resource_value_token1,
+    STATE(23), 1,
+      aux_sym_resource_repeat1,
+    STATE(31), 1,
+      aux_sym_resource_value_repeat1,
+    STATE(71), 1,
+      sym_resource_value,
+  [211] = 4,
     ACTIONS(130), 1,
+      anon_sym_COLON,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    STATE(20), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [227] = 7,
+    ACTIONS(3), 1,
+      sym_preprocessor_comment,
+    ACTIONS(126), 1,
+      sym_escape_sequence,
+    ACTIONS(128), 1,
+      aux_sym_resource_value_token1,
+    ACTIONS(132), 1,
+      aux_sym_resource_token1,
+    STATE(31), 1,
+      aux_sym_resource_value_repeat1,
+    STATE(39), 1,
+      aux_sym_resource_repeat1,
+    STATE(53), 1,
+      sym_resource_value,
+  [249] = 4,
+    ACTIONS(134), 1,
+      anon_sym_COLON,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    STATE(20), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [265] = 4,
+    ACTIONS(136), 1,
+      anon_sym_COLON,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    STATE(20), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [281] = 3,
+    ACTIONS(140), 1,
+      aux_sym_elif_directive_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(138), 4,
+      aux_sym__if_directive_body_token1,
+      aux_sym_elifdef_directive_token1,
+      aux_sym_elifdef_directive_token2,
+      aux_sym_else_directive_token1,
+  [295] = 3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    STATE(20), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [308] = 5,
+    ACTIONS(142), 1,
+      aux_sym__line_token1,
+    ACTIONS(144), 1,
+      sym_escape_sequence,
+    ACTIONS(147), 1,
+      aux_sym_resource_value_token1,
+    STATE(28), 1,
+      aux_sym_resource_value_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [325] = 5,
+    ACTIONS(150), 1,
+      aux_sym__line_token1,
+    ACTIONS(152), 1,
+      anon_sym_LPAREN,
+    ACTIONS(154), 1,
       sym_expansion,
-    STATE(42), 1,
+    STATE(45), 1,
       sym_parameters,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [347] = 4,
-    ACTIONS(132), 1,
-      anon_sym_COMMA,
-    ACTIONS(135), 1,
-      anon_sym_RPAREN,
-    STATE(29), 1,
-      aux_sym_parameters_repeat1,
+  [342] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [361] = 3,
-    ACTIONS(139), 1,
-      anon_sym_RPAREN,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(137), 2,
-      anon_sym_DOT_DOT_DOT,
-      sym_identifier,
-  [373] = 4,
-    ACTIONS(15), 1,
-      sym_any_component,
-    ACTIONS(76), 1,
+    ACTIONS(156), 4,
+      anon_sym_DOT,
+      anon_sym_STAR,
       sym_component,
-    STATE(35), 1,
+      sym_any_component,
+  [353] = 5,
+    ACTIONS(158), 1,
+      aux_sym__line_token1,
+    ACTIONS(160), 1,
+      sym_escape_sequence,
+    ACTIONS(162), 1,
+      aux_sym_resource_value_token1,
+    STATE(28), 1,
+      aux_sym_resource_value_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [370] = 3,
+    STATE(32), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [387] = 4,
-    ACTIONS(141), 1,
+    ACTIONS(164), 2,
+      sym_component,
+      sym_any_component,
+  [382] = 3,
+    ACTIONS(169), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(167), 2,
+      anon_sym_DOT_DOT_DOT,
+      sym_identifier,
+  [394] = 4,
+    ACTIONS(171), 1,
       anon_sym_COMMA,
-    ACTIONS(143), 1,
+    ACTIONS(173), 1,
+      anon_sym_RPAREN,
+    STATE(35), 1,
+      aux_sym_parameters_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [408] = 4,
+    ACTIONS(171), 1,
+      anon_sym_COMMA,
+    ACTIONS(175), 1,
       anon_sym_RPAREN,
     STATE(36), 1,
       aux_sym_parameters_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [401] = 4,
-    ACTIONS(15), 1,
-      sym_any_component,
-    ACTIONS(145), 1,
-      sym_component,
-    STATE(35), 1,
-      aux_sym_components_repeat2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [415] = 5,
-    ACTIONS(3), 1,
-      sym_preprocessor_comment,
-    ACTIONS(147), 1,
-      aux_sym_resource_token1,
-    ACTIONS(150), 1,
-      sym_escape_sequence,
-    ACTIONS(152), 1,
-      aux_sym_resource_value_token1,
-    STATE(34), 1,
-      aux_sym_resource_repeat1,
-  [431] = 3,
-    STATE(35), 1,
-      aux_sym_components_repeat2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(154), 2,
-      sym_component,
-      sym_any_component,
-  [443] = 4,
-    ACTIONS(141), 1,
+  [422] = 4,
+    ACTIONS(177), 1,
       anon_sym_COMMA,
-    ACTIONS(157), 1,
+    ACTIONS(180), 1,
       anon_sym_RPAREN,
-    STATE(29), 1,
+    STATE(36), 1,
       aux_sym_parameters_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [457] = 3,
-    ACTIONS(159), 1,
-      aux_sym__line_token1,
-    ACTIONS(161), 1,
-      sym_expansion,
+  [436] = 4,
+    ACTIONS(15), 1,
+      sym_any_component,
+    ACTIONS(115), 1,
+      sym_component,
+    STATE(32), 1,
+      aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [468] = 3,
-    ACTIONS(163), 1,
+  [450] = 4,
+    ACTIONS(15), 1,
+      sym_any_component,
+    ACTIONS(182), 1,
+      sym_component,
+    STATE(32), 1,
+      aux_sym_components_repeat2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [464] = 5,
+    ACTIONS(3), 1,
+      sym_preprocessor_comment,
+    ACTIONS(184), 1,
+      aux_sym_resource_token1,
+    ACTIONS(187), 1,
+      sym_escape_sequence,
+    ACTIONS(189), 1,
+      aux_sym_resource_value_token1,
+    STATE(39), 1,
+      aux_sym_resource_repeat1,
+  [480] = 2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(180), 2,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+  [489] = 3,
+    ACTIONS(191), 1,
       anon_sym_DQUOTE,
-    STATE(55), 1,
+    STATE(68), 1,
       sym_string,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [479] = 3,
-    ACTIONS(165), 1,
+  [500] = 3,
+    ACTIONS(193), 1,
       aux_sym__line_token1,
-    ACTIONS(167), 1,
+    ACTIONS(195), 1,
       sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [490] = 2,
+  [511] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(169), 2,
+    ACTIONS(197), 2,
       anon_sym_DOT_DOT_DOT,
       sym_identifier,
-  [499] = 3,
-    ACTIONS(171), 1,
-      aux_sym__line_token1,
-    ACTIONS(173), 1,
-      sym_expansion,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [510] = 3,
-    ACTIONS(175), 1,
-      aux_sym__line_token1,
-    ACTIONS(177), 1,
-      sym_expansion,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [521] = 2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(135), 2,
-      anon_sym_COMMA,
-      anon_sym_RPAREN,
-  [530] = 2,
-    ACTIONS(179), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [538] = 2,
-    ACTIONS(181), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [546] = 2,
-    ACTIONS(183), 1,
-      aux_sym_ifdef_directive_token3,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [554] = 2,
-    ACTIONS(185), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [562] = 2,
-    ACTIONS(189), 1,
-      aux_sym_string_token1,
-    ACTIONS(187), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [570] = 2,
-    ACTIONS(191), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [578] = 2,
-    ACTIONS(193), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [586] = 2,
-    ACTIONS(195), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [594] = 2,
-    ACTIONS(197), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [602] = 2,
+  [520] = 3,
     ACTIONS(199), 1,
       aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [610] = 2,
     ACTIONS(201), 1,
-      sym_identifier,
+      sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [618] = 2,
+  [531] = 3,
     ACTIONS(203), 1,
       aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [626] = 2,
     ACTIONS(205), 1,
-      anon_sym_DQUOTE,
+      sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [634] = 2,
+  [542] = 3,
     ACTIONS(207), 1,
       aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [642] = 2,
     ACTIONS(209), 1,
-      aux_sym__line_token1,
+      sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [650] = 2,
-    ACTIONS(211), 1,
-      aux_sym_ifdef_directive_token3,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [658] = 2,
+  [553] = 2,
     ACTIONS(213), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
+      aux_sym_string_token1,
+    ACTIONS(211), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [666] = 2,
+  [561] = 2,
     ACTIONS(215), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [674] = 2,
+  [569] = 2,
     ACTIONS(217), 1,
-      aux_sym_ifdef_directive_token3,
+      aux_sym__if_directive_body_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [682] = 2,
+  [577] = 2,
     ACTIONS(219), 1,
-      aux_sym__line_token1,
+      anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [690] = 2,
+  [585] = 2,
     ACTIONS(221), 1,
-      aux_sym__line_token1,
+      sym_identifier,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [698] = 2,
+  [593] = 2,
     ACTIONS(223), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [706] = 2,
+  [601] = 2,
     ACTIONS(225), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [714] = 2,
+  [609] = 2,
     ACTIONS(227), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [722] = 2,
+  [617] = 2,
     ACTIONS(229), 1,
-      ts_builtin_sym_end,
+      sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [730] = 2,
+  [625] = 2,
     ACTIONS(231), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [738] = 2,
+  [633] = 2,
     ACTIONS(233), 1,
-      aux_sym__line_token1,
+      sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [746] = 2,
+  [641] = 2,
     ACTIONS(235), 1,
-      aux_sym_ifdef_directive_token3,
+      sym_identifier,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [754] = 2,
+  [649] = 2,
     ACTIONS(237), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [657] = 2,
+    ACTIONS(239), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [762] = 2,
-    ACTIONS(239), 1,
+  [665] = 2,
+    ACTIONS(241), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [673] = 2,
+    ACTIONS(243), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [681] = 2,
+    ACTIONS(245), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [689] = 2,
+    ACTIONS(247), 1,
+      aux_sym__if_directive_body_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [697] = 2,
+    ACTIONS(249), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [705] = 2,
+    ACTIONS(251), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [713] = 2,
+    ACTIONS(253), 1,
+      aux_sym__if_directive_body_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [721] = 2,
+    ACTIONS(255), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [729] = 2,
+    ACTIONS(257), 1,
+      ts_builtin_sym_end,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [737] = 2,
+    ACTIONS(259), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [745] = 2,
+    ACTIONS(261), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [753] = 2,
+    ACTIONS(263), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [761] = 2,
+    ACTIONS(265), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [769] = 2,
+    ACTIONS(267), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [777] = 2,
+    ACTIONS(269), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [785] = 2,
+    ACTIONS(271), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [793] = 2,
+    ACTIONS(273), 1,
+      aux_sym__if_directive_body_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [801] = 2,
+    ACTIONS(275), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [809] = 2,
+    ACTIONS(277), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [817] = 2,
+    ACTIONS(279), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -2128,70 +2351,74 @@ static const uint16_t ts_small_parse_table[] = {
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(10)] = 0,
-  [SMALL_STATE(11)] = 23,
-  [SMALL_STATE(12)] = 46,
-  [SMALL_STATE(13)] = 68,
-  [SMALL_STATE(14)] = 92,
-  [SMALL_STATE(15)] = 116,
-  [SMALL_STATE(16)] = 133,
-  [SMALL_STATE(17)] = 150,
-  [SMALL_STATE(18)] = 169,
-  [SMALL_STATE(19)] = 185,
-  [SMALL_STATE(20)] = 207,
-  [SMALL_STATE(21)] = 223,
-  [SMALL_STATE(22)] = 245,
-  [SMALL_STATE(23)] = 261,
-  [SMALL_STATE(24)] = 274,
-  [SMALL_STATE(25)] = 285,
-  [SMALL_STATE(26)] = 302,
-  [SMALL_STATE(27)] = 313,
-  [SMALL_STATE(28)] = 330,
-  [SMALL_STATE(29)] = 347,
-  [SMALL_STATE(30)] = 361,
-  [SMALL_STATE(31)] = 373,
-  [SMALL_STATE(32)] = 387,
-  [SMALL_STATE(33)] = 401,
-  [SMALL_STATE(34)] = 415,
-  [SMALL_STATE(35)] = 431,
-  [SMALL_STATE(36)] = 443,
-  [SMALL_STATE(37)] = 457,
-  [SMALL_STATE(38)] = 468,
-  [SMALL_STATE(39)] = 479,
-  [SMALL_STATE(40)] = 490,
-  [SMALL_STATE(41)] = 499,
-  [SMALL_STATE(42)] = 510,
-  [SMALL_STATE(43)] = 521,
-  [SMALL_STATE(44)] = 530,
-  [SMALL_STATE(45)] = 538,
-  [SMALL_STATE(46)] = 546,
-  [SMALL_STATE(47)] = 554,
-  [SMALL_STATE(48)] = 562,
-  [SMALL_STATE(49)] = 570,
-  [SMALL_STATE(50)] = 578,
-  [SMALL_STATE(51)] = 586,
-  [SMALL_STATE(52)] = 594,
-  [SMALL_STATE(53)] = 602,
-  [SMALL_STATE(54)] = 610,
-  [SMALL_STATE(55)] = 618,
-  [SMALL_STATE(56)] = 626,
-  [SMALL_STATE(57)] = 634,
-  [SMALL_STATE(58)] = 642,
-  [SMALL_STATE(59)] = 650,
-  [SMALL_STATE(60)] = 658,
-  [SMALL_STATE(61)] = 666,
-  [SMALL_STATE(62)] = 674,
-  [SMALL_STATE(63)] = 682,
-  [SMALL_STATE(64)] = 690,
-  [SMALL_STATE(65)] = 698,
-  [SMALL_STATE(66)] = 706,
-  [SMALL_STATE(67)] = 714,
-  [SMALL_STATE(68)] = 722,
-  [SMALL_STATE(69)] = 730,
-  [SMALL_STATE(70)] = 738,
-  [SMALL_STATE(71)] = 746,
-  [SMALL_STATE(72)] = 754,
-  [SMALL_STATE(73)] = 762,
+  [SMALL_STATE(13)] = 0,
+  [SMALL_STATE(14)] = 27,
+  [SMALL_STATE(15)] = 54,
+  [SMALL_STATE(16)] = 82,
+  [SMALL_STATE(17)] = 110,
+  [SMALL_STATE(18)] = 133,
+  [SMALL_STATE(19)] = 155,
+  [SMALL_STATE(20)] = 172,
+  [SMALL_STATE(21)] = 189,
+  [SMALL_STATE(22)] = 211,
+  [SMALL_STATE(23)] = 227,
+  [SMALL_STATE(24)] = 249,
+  [SMALL_STATE(25)] = 265,
+  [SMALL_STATE(26)] = 281,
+  [SMALL_STATE(27)] = 295,
+  [SMALL_STATE(28)] = 308,
+  [SMALL_STATE(29)] = 325,
+  [SMALL_STATE(30)] = 342,
+  [SMALL_STATE(31)] = 353,
+  [SMALL_STATE(32)] = 370,
+  [SMALL_STATE(33)] = 382,
+  [SMALL_STATE(34)] = 394,
+  [SMALL_STATE(35)] = 408,
+  [SMALL_STATE(36)] = 422,
+  [SMALL_STATE(37)] = 436,
+  [SMALL_STATE(38)] = 450,
+  [SMALL_STATE(39)] = 464,
+  [SMALL_STATE(40)] = 480,
+  [SMALL_STATE(41)] = 489,
+  [SMALL_STATE(42)] = 500,
+  [SMALL_STATE(43)] = 511,
+  [SMALL_STATE(44)] = 520,
+  [SMALL_STATE(45)] = 531,
+  [SMALL_STATE(46)] = 542,
+  [SMALL_STATE(47)] = 553,
+  [SMALL_STATE(48)] = 561,
+  [SMALL_STATE(49)] = 569,
+  [SMALL_STATE(50)] = 577,
+  [SMALL_STATE(51)] = 585,
+  [SMALL_STATE(52)] = 593,
+  [SMALL_STATE(53)] = 601,
+  [SMALL_STATE(54)] = 609,
+  [SMALL_STATE(55)] = 617,
+  [SMALL_STATE(56)] = 625,
+  [SMALL_STATE(57)] = 633,
+  [SMALL_STATE(58)] = 641,
+  [SMALL_STATE(59)] = 649,
+  [SMALL_STATE(60)] = 657,
+  [SMALL_STATE(61)] = 665,
+  [SMALL_STATE(62)] = 673,
+  [SMALL_STATE(63)] = 681,
+  [SMALL_STATE(64)] = 689,
+  [SMALL_STATE(65)] = 697,
+  [SMALL_STATE(66)] = 705,
+  [SMALL_STATE(67)] = 713,
+  [SMALL_STATE(68)] = 721,
+  [SMALL_STATE(69)] = 729,
+  [SMALL_STATE(70)] = 737,
+  [SMALL_STATE(71)] = 745,
+  [SMALL_STATE(72)] = 753,
+  [SMALL_STATE(73)] = 761,
+  [SMALL_STATE(74)] = 769,
+  [SMALL_STATE(75)] = 777,
+  [SMALL_STATE(76)] = 785,
+  [SMALL_STATE(77)] = 793,
+  [SMALL_STATE(78)] = 801,
+  [SMALL_STATE(79)] = 809,
+  [SMALL_STATE(80)] = 817,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -2199,115 +2426,134 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 0, 0, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
   [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
-  [35] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(10),
-  [38] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(65),
-  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(24),
-  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
-  [47] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(23),
-  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(38),
-  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(50),
-  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(47),
-  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(67),
-  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elifdef_directive, 2, 0, 7),
-  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elifdef_directive, 3, 0, 7),
-  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
-  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
-  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
-  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
-  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
-  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [78] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [80] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
-  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(24),
-  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
-  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_ifdef_directive_repeat1, 2, 0, 13),
-  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_ifdef_directive_repeat1, 2, 0, 13), SHIFT_REPEAT(54),
-  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
-  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [100] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
-  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
-  [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
-  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
-  [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [114] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
-  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_ifdef_directive_repeat1, 1, 0, 8),
-  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
-  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
-  [123] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
-  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
-  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [130] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
-  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0), SHIFT_REPEAT(40),
-  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0),
-  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [147] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(34),
-  [150] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [152] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [154] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(23),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 4, 0, 0),
-  [161] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 4, 0, 0),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 2, 0, 0),
-  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 2, 0, 0),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 3, 0, 0),
-  [173] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 3, 0, 0),
-  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 3, 0, 4),
-  [177] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
-  [179] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
-  [181] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 5),
-  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [187] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [189] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
-  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 9),
-  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [197] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 4, 0, 6),
-  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 7),
-  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
-  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 10),
-  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 11),
-  [211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_undef_directive, 2, 0, 2),
-  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 12),
-  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [219] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
-  [227] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [229] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 14),
-  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 15),
-  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 16),
-  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 7, 0, 17),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
+  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(13),
+  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(48),
+  [47] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(30),
+  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
+  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
+  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(41),
+  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(51),
+  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(54),
+  [65] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(55),
+  [68] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(58),
+  [71] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
+  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elif_directive, 2, 0, 10),
+  [75] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_directive, 2, 0, 10),
+  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elifdef_directive, 2, 0, 10),
+  [79] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elifdef_directive, 2, 0, 10),
+  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elif_directive, 3, 0, 10),
+  [83] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_directive, 3, 0, 10),
+  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elifdef_directive, 3, 0, 10),
+  [87] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elifdef_directive, 3, 0, 10),
+  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
+  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
+  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
+  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
+  [101] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__line, 2, 0, 0),
+  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__if_directive_body_repeat1, 2, 0, 13),
+  [109] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__if_directive_body_repeat1, 2, 0, 13), SHIFT_REPEAT(57),
+  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__if_directive_body_repeat1, 2, 0, 13), SHIFT_REPEAT(65),
+  [115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [117] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(30),
+  [120] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
+  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
+  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [128] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
+  [130] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
+  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [134] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
+  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
+  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__if_directive_body_repeat1, 1, 0, 8),
+  [140] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__if_directive_body_repeat1, 1, 0, 8),
+  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
+  [144] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
+  [147] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
+  [150] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
+  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [154] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
+  [156] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
+  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [162] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
+  [164] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(27),
+  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [177] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0), SHIFT_REPEAT(43),
+  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [184] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(39),
+  [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [189] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [193] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 2, 0, 0),
+  [195] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 2, 0, 0),
+  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 3, 0, 0),
+  [201] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 3, 0, 0),
+  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 3, 0, 4),
+  [205] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
+  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 4, 0, 0),
+  [209] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 4, 0, 0),
+  [211] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [213] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
+  [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [219] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 7),
+  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 9),
+  [227] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [229] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
+  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 4, 0, 6),
+  [233] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
+  [235] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
+  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
+  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 2, 0, 8),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_directive, 4, 0, 7),
+  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 2, 0, 12),
+  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
+  [257] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 5),
+  [263] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_undef_directive, 2, 0, 2),
+  [265] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 3, 0, 14),
+  [271] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 3, 0, 15),
+  [273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 3, 0, 16),
+  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 4, 0, 17),
+  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__if_directive_body, 2, 0, 11),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,15 +5,15 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 53
+#define STATE_COUNT 61
 #define LARGE_STATE_COUNT 8
-#define SYMBOL_COUNT 41
+#define SYMBOL_COUNT 48
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 23
+#define TOKEN_COUNT 27
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 6
+#define FIELD_COUNT 7
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
-#define PRODUCTION_ID_COUNT 11
+#define PRODUCTION_ID_COUNT 12
 
 enum ts_symbol_identifiers {
   aux_sym__line_token1 = 1,
@@ -31,32 +31,39 @@ enum ts_symbol_identifiers {
   aux_sym_string_token1 = 13,
   aux_sym_include_directive_token1 = 14,
   aux_sym_define_directive_token1 = 15,
-  sym_expansion = 16,
-  aux_sym_undef_directive_token1 = 17,
-  aux_sym_ifdef_directive_token1 = 18,
-  aux_sym_ifdef_directive_token2 = 19,
-  aux_sym_ifdef_directive_token3 = 20,
-  aux_sym_else_directive_token1 = 21,
-  sym_identifier = 22,
-  sym_resources = 23,
-  sym__line = 24,
-  sym__statement = 25,
-  sym_resource = 26,
-  sym_components = 27,
-  sym_binding = 28,
-  sym_resource_value = 29,
-  sym_string = 30,
-  sym_include_directive = 31,
-  sym_define_directive = 32,
-  sym_undef_directive = 33,
-  sym_ifdef_directive = 34,
-  sym_else_directive = 35,
-  aux_sym_resources_repeat1 = 36,
-  aux_sym_resource_repeat1 = 37,
-  aux_sym_components_repeat1 = 38,
-  aux_sym_components_repeat2 = 39,
-  aux_sym_resource_value_repeat1 = 40,
-  alias_sym_body = 41,
+  anon_sym_LPAREN = 16,
+  anon_sym_DOT_DOT_DOT = 17,
+  anon_sym_COMMA = 18,
+  anon_sym_RPAREN = 19,
+  sym_expansion = 20,
+  aux_sym_undef_directive_token1 = 21,
+  aux_sym_ifdef_directive_token1 = 22,
+  aux_sym_ifdef_directive_token2 = 23,
+  aux_sym_ifdef_directive_token3 = 24,
+  aux_sym_else_directive_token1 = 25,
+  sym_identifier = 26,
+  sym_resources = 27,
+  sym__line = 28,
+  sym__statement = 29,
+  sym_resource = 30,
+  sym_components = 31,
+  sym_binding = 32,
+  sym_resource_value = 33,
+  sym_string = 34,
+  sym_include_directive = 35,
+  sym_define_directive = 36,
+  sym_define_function_directive = 37,
+  sym_parameters = 38,
+  sym_undef_directive = 39,
+  sym_ifdef_directive = 40,
+  sym_else_directive = 41,
+  aux_sym_resources_repeat1 = 42,
+  aux_sym_resource_repeat1 = 43,
+  aux_sym_components_repeat1 = 44,
+  aux_sym_components_repeat2 = 45,
+  aux_sym_resource_value_repeat1 = 46,
+  aux_sym_parameters_repeat1 = 47,
+  alias_sym_body = 48,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -76,6 +83,10 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_string_token1] = "string_content",
   [aux_sym_include_directive_token1] = "#include",
   [aux_sym_define_directive_token1] = "#define",
+  [anon_sym_LPAREN] = "(",
+  [anon_sym_DOT_DOT_DOT] = "...",
+  [anon_sym_COMMA] = ",",
+  [anon_sym_RPAREN] = ")",
   [sym_expansion] = "expansion",
   [aux_sym_undef_directive_token1] = "#undef",
   [aux_sym_ifdef_directive_token1] = "#ifdef",
@@ -93,6 +104,8 @@ static const char * const ts_symbol_names[] = {
   [sym_string] = "string",
   [sym_include_directive] = "include_directive",
   [sym_define_directive] = "define_directive",
+  [sym_define_function_directive] = "define_function_directive",
+  [sym_parameters] = "parameters",
   [sym_undef_directive] = "undef_directive",
   [sym_ifdef_directive] = "ifdef_directive",
   [sym_else_directive] = "else_directive",
@@ -101,6 +114,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_components_repeat1] = "components_repeat1",
   [aux_sym_components_repeat2] = "components_repeat2",
   [aux_sym_resource_value_repeat1] = "resource_value_repeat1",
+  [aux_sym_parameters_repeat1] = "parameters_repeat1",
   [alias_sym_body] = "body",
 };
 
@@ -121,6 +135,10 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_string_token1] = aux_sym_string_token1,
   [aux_sym_include_directive_token1] = aux_sym_include_directive_token1,
   [aux_sym_define_directive_token1] = aux_sym_define_directive_token1,
+  [anon_sym_LPAREN] = anon_sym_LPAREN,
+  [anon_sym_DOT_DOT_DOT] = anon_sym_DOT_DOT_DOT,
+  [anon_sym_COMMA] = anon_sym_COMMA,
+  [anon_sym_RPAREN] = anon_sym_RPAREN,
   [sym_expansion] = sym_expansion,
   [aux_sym_undef_directive_token1] = aux_sym_undef_directive_token1,
   [aux_sym_ifdef_directive_token1] = aux_sym_ifdef_directive_token1,
@@ -138,6 +156,8 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_string] = sym_string,
   [sym_include_directive] = sym_include_directive,
   [sym_define_directive] = sym_define_directive,
+  [sym_define_function_directive] = sym_define_function_directive,
+  [sym_parameters] = sym_parameters,
   [sym_undef_directive] = sym_undef_directive,
   [sym_ifdef_directive] = sym_ifdef_directive,
   [sym_else_directive] = sym_else_directive,
@@ -146,6 +166,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_components_repeat1] = aux_sym_components_repeat1,
   [aux_sym_components_repeat2] = aux_sym_components_repeat2,
   [aux_sym_resource_value_repeat1] = aux_sym_resource_value_repeat1,
+  [aux_sym_parameters_repeat1] = aux_sym_parameters_repeat1,
   [alias_sym_body] = alias_sym_body,
 };
 
@@ -211,6 +232,22 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym_define_directive_token1] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DOT_DOT_DOT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_COMMA] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RPAREN] = {
     .visible = true,
     .named = false,
   },
@@ -282,6 +319,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_define_function_directive] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_parameters] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_undef_directive] = {
     .visible = true,
     .named = true,
@@ -314,6 +359,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [aux_sym_parameters_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
   [alias_sym_body] = {
     .visible = true,
     .named = true,
@@ -326,7 +375,8 @@ enum ts_field_identifiers {
   field_consequence = 3,
   field_file = 4,
   field_name = 5,
-  field_value = 6,
+  field_parameters = 6,
+  field_value = 7,
 };
 
 static const char * const ts_field_names[] = {
@@ -336,6 +386,7 @@ static const char * const ts_field_names[] = {
   [field_consequence] = "consequence",
   [field_file] = "file",
   [field_name] = "name",
+  [field_parameters] = "parameters",
   [field_value] = "value",
 };
 
@@ -345,11 +396,12 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [3] = {.index = 2, .length = 2},
   [4] = {.index = 4, .length = 2},
   [5] = {.index = 6, .length = 2},
-  [6] = {.index = 8, .length = 1},
-  [7] = {.index = 9, .length = 2},
-  [8] = {.index = 11, .length = 2},
-  [9] = {.index = 13, .length = 2},
-  [10] = {.index = 15, .length = 3},
+  [6] = {.index = 8, .length = 3},
+  [7] = {.index = 11, .length = 1},
+  [8] = {.index = 12, .length = 2},
+  [9] = {.index = 14, .length = 2},
+  [10] = {.index = 16, .length = 2},
+  [11] = {.index = 18, .length = 3},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
@@ -361,23 +413,27 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
     {field_name, 1},
     {field_value, 2},
   [4] =
+    {field_name, 1},
+    {field_parameters, 2},
+  [6] =
     {field_name, 0},
     {field_value, 2},
-  [6] =
-    {field_name, 1},
-    {field_value, 3},
   [8] =
-    {field_condition, 1},
-  [9] =
-    {field_name, 0},
+    {field_name, 1},
+    {field_parameters, 2},
     {field_value, 3},
   [11] =
+    {field_condition, 1},
+  [12] =
+    {field_name, 0},
+    {field_value, 3},
+  [14] =
     {field_alternative, 3},
     {field_condition, 1},
-  [13] =
+  [16] =
     {field_condition, 1},
     {field_consequence, 3},
-  [15] =
+  [18] =
     {field_alternative, 4},
     {field_condition, 1},
     {field_consequence, 3},
@@ -385,10 +441,10 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
-  [9] = {
+  [10] = {
     [3] = alias_sym_body,
   },
-  [10] = {
+  [11] = {
     [3] = alias_sym_body,
   },
 };
@@ -429,7 +485,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [25] = 25,
   [26] = 26,
   [27] = 27,
-  [28] = 26,
+  [28] = 28,
   [29] = 29,
   [30] = 30,
   [31] = 31,
@@ -454,6 +510,14 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [50] = 50,
   [51] = 51,
   [52] = 52,
+  [53] = 53,
+  [54] = 54,
+  [55] = 55,
+  [56] = 56,
+  [57] = 57,
+  [58] = 58,
+  [59] = 59,
+  [60] = 60,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -461,465 +525,541 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(40);
+      if (eof) ADVANCE(44);
       ADVANCE_MAP(
-        '\n', 41,
-        '!', 42,
-        '"', 68,
-        '#', 66,
-        '*', 59,
-        '.', 58,
-        '/', 65,
-        ':', 55,
-        '?', 62,
-        '\\', 67,
-        '\t', 56,
-        ' ', 56,
-      );
-      if (('-' <= lookahead && lookahead <= '9')) ADVANCE(61);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      if (lookahead != 0) ADVANCE(64);
-      END_STATE();
-    case 1:
-      if (lookahead == '\n') ADVANCE(41);
-      if (lookahead == '/') ADVANCE(65);
-      if (lookahead == '\\') ADVANCE(67);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(56);
-      if (lookahead != 0) ADVANCE(64);
-      END_STATE();
-    case 2:
-      if (lookahead == '\n') ADVANCE(41);
-      if (lookahead == '/') ADVANCE(80);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(56);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(82);
-      END_STATE();
-    case 3:
-      if (lookahead == '\r') ADVANCE(50);
-      if (lookahead == '\\') ADVANCE(45);
-      if (lookahead != 0) ADVANCE(49);
-      END_STATE();
-    case 4:
-      if (lookahead == '*') ADVANCE(6);
-      if (lookahead == '/') ADVANCE(49);
-      END_STATE();
-    case 5:
-      if (lookahead == '*') ADVANCE(5);
-      if (lookahead == '/') ADVANCE(43);
-      if (lookahead != 0) ADVANCE(6);
-      END_STATE();
-    case 6:
-      if (lookahead == '*') ADVANCE(5);
-      if (lookahead != 0) ADVANCE(6);
-      END_STATE();
-    case 7:
-      if (lookahead == '/') ADVANCE(4);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(56);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(38);
-      END_STATE();
-    case 8:
-      if (lookahead == 'c') ADVANCE(31);
-      END_STATE();
-    case 9:
-      if (lookahead == 'd') ADVANCE(15);
-      if (lookahead == 'e') ADVANCE(30);
-      if (lookahead == 'i') ADVANCE(22);
-      if (lookahead == 'u') ADVANCE(32);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(9);
-      END_STATE();
-    case 10:
-      if (lookahead == 'd') ADVANCE(29);
-      END_STATE();
-    case 11:
-      if (lookahead == 'd') ADVANCE(18);
-      END_STATE();
-    case 12:
-      if (lookahead == 'd') ADVANCE(19);
-      if (lookahead == 'n') ADVANCE(14);
-      END_STATE();
-    case 13:
-      if (lookahead == 'd') ADVANCE(20);
-      END_STATE();
-    case 14:
-      if (lookahead == 'd') ADVANCE(21);
-      END_STATE();
-    case 15:
-      if (lookahead == 'e') ADVANCE(23);
-      END_STATE();
-    case 16:
-      if (lookahead == 'e') ADVANCE(88);
-      END_STATE();
-    case 17:
-      if (lookahead == 'e') ADVANCE(76);
-      END_STATE();
-    case 18:
-      if (lookahead == 'e') ADVANCE(75);
-      END_STATE();
-    case 19:
-      if (lookahead == 'e') ADVANCE(25);
-      END_STATE();
-    case 20:
-      if (lookahead == 'e') ADVANCE(26);
-      END_STATE();
-    case 21:
-      if (lookahead == 'e') ADVANCE(27);
-      END_STATE();
-    case 22:
-      if (lookahead == 'f') ADVANCE(12);
-      if (lookahead == 'n') ADVANCE(8);
-      END_STATE();
-    case 23:
-      if (lookahead == 'f') ADVANCE(28);
-      END_STATE();
-    case 24:
-      if (lookahead == 'f') ADVANCE(87);
-      END_STATE();
-    case 25:
-      if (lookahead == 'f') ADVANCE(85);
-      END_STATE();
-    case 26:
-      if (lookahead == 'f') ADVANCE(84);
-      END_STATE();
-    case 27:
-      if (lookahead == 'f') ADVANCE(86);
-      END_STATE();
-    case 28:
-      if (lookahead == 'i') ADVANCE(33);
-      END_STATE();
-    case 29:
-      if (lookahead == 'i') ADVANCE(24);
-      END_STATE();
-    case 30:
-      if (lookahead == 'l') ADVANCE(34);
-      if (lookahead == 'n') ADVANCE(10);
-      END_STATE();
-    case 31:
-      if (lookahead == 'l') ADVANCE(35);
-      END_STATE();
-    case 32:
-      if (lookahead == 'n') ADVANCE(13);
-      END_STATE();
-    case 33:
-      if (lookahead == 'n') ADVANCE(17);
-      END_STATE();
-    case 34:
-      if (lookahead == 's') ADVANCE(16);
-      END_STATE();
-    case 35:
-      if (lookahead == 'u') ADVANCE(11);
-      END_STATE();
-    case 36:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(63);
-      END_STATE();
-    case 37:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(36);
-      END_STATE();
-    case 38:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
-      END_STATE();
-    case 39:
-      if (eof) ADVANCE(40);
-      ADVANCE_MAP(
-        '\n', 41,
-        '!', 42,
-        '"', 68,
-        '#', 9,
-        '*', 59,
-        '.', 58,
-        '/', 4,
-        ':', 55,
-        '?', 62,
-        '\t', 56,
-        ' ', 56,
+        '\n', 45,
+        '!', 48,
+        '(', 83,
+        ')', 86,
+        '*', 67,
+        ',', 85,
+        '.', 66,
+        '/', 93,
+        ':', 63,
+        '?', 69,
+        '\t', 64,
+        ' ', 64,
       );
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(61);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(95);
+      END_STATE();
+    case 1:
+      if (lookahead == '\n') ADVANCE(45);
+      if (lookahead == '(') ADVANCE(83);
+      if (lookahead == '/') ADVANCE(93);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(64);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(95);
+      END_STATE();
+    case 2:
+      if (lookahead == '\n') ADVANCE(45);
+      if (lookahead == '/') ADVANCE(93);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(64);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(95);
+      END_STATE();
+    case 3:
+      if (lookahead == '\n') ADVANCE(45);
+      if (lookahead == '/') ADVANCE(72);
+      if (lookahead == '\\') ADVANCE(73);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(64);
+      if (lookahead != 0) ADVANCE(71);
+      END_STATE();
+    case 4:
+      if (lookahead == '\r') ADVANCE(60);
+      if (lookahead == '\\') ADVANCE(52);
+      if (lookahead != 0) ADVANCE(59);
+      END_STATE();
+    case 5:
+      if (lookahead == ')') ADVANCE(86);
+      if (lookahead == '.') ADVANCE(11);
+      if (lookahead == '/') ADVANCE(6);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(64);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(102);
+      END_STATE();
+    case 6:
+      if (lookahead == '*') ADVANCE(9);
+      if (lookahead == '/') ADVANCE(59);
+      END_STATE();
+    case 7:
+      if (lookahead == '*') ADVANCE(7);
+      if (lookahead == '/') ADVANCE(50);
+      if (lookahead != 0) ADVANCE(9);
+      END_STATE();
+    case 8:
+      if (lookahead == '*') ADVANCE(7);
+      if (lookahead != 0) ADVANCE(88);
+      END_STATE();
+    case 9:
+      if (lookahead == '*') ADVANCE(7);
+      if (lookahead != 0) ADVANCE(9);
+      END_STATE();
+    case 10:
+      if (lookahead == '.') ADVANCE(84);
+      END_STATE();
+    case 11:
+      if (lookahead == '.') ADVANCE(10);
+      END_STATE();
+    case 12:
+      if (lookahead == 'c') ADVANCE(35);
+      END_STATE();
+    case 13:
+      if (lookahead == 'd') ADVANCE(19);
+      if (lookahead == 'e') ADVANCE(34);
+      if (lookahead == 'i') ADVANCE(26);
+      if (lookahead == 'u') ADVANCE(36);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(13);
+      END_STATE();
+    case 14:
+      if (lookahead == 'd') ADVANCE(33);
+      END_STATE();
+    case 15:
+      if (lookahead == 'd') ADVANCE(22);
+      END_STATE();
+    case 16:
+      if (lookahead == 'd') ADVANCE(23);
+      if (lookahead == 'n') ADVANCE(18);
+      END_STATE();
+    case 17:
+      if (lookahead == 'd') ADVANCE(24);
+      END_STATE();
+    case 18:
+      if (lookahead == 'd') ADVANCE(25);
+      END_STATE();
+    case 19:
+      if (lookahead == 'e') ADVANCE(27);
+      END_STATE();
+    case 20:
+      if (lookahead == 'e') ADVANCE(101);
+      END_STATE();
+    case 21:
+      if (lookahead == 'e') ADVANCE(82);
+      END_STATE();
+    case 22:
+      if (lookahead == 'e') ADVANCE(81);
+      END_STATE();
+    case 23:
+      if (lookahead == 'e') ADVANCE(29);
+      END_STATE();
+    case 24:
+      if (lookahead == 'e') ADVANCE(30);
+      END_STATE();
+    case 25:
+      if (lookahead == 'e') ADVANCE(31);
+      END_STATE();
+    case 26:
+      if (lookahead == 'f') ADVANCE(16);
+      if (lookahead == 'n') ADVANCE(12);
+      END_STATE();
+    case 27:
+      if (lookahead == 'f') ADVANCE(32);
+      END_STATE();
+    case 28:
+      if (lookahead == 'f') ADVANCE(100);
+      END_STATE();
+    case 29:
+      if (lookahead == 'f') ADVANCE(98);
+      END_STATE();
+    case 30:
+      if (lookahead == 'f') ADVANCE(97);
+      END_STATE();
+    case 31:
+      if (lookahead == 'f') ADVANCE(99);
+      END_STATE();
+    case 32:
+      if (lookahead == 'i') ADVANCE(37);
+      END_STATE();
+    case 33:
+      if (lookahead == 'i') ADVANCE(28);
+      END_STATE();
+    case 34:
+      if (lookahead == 'l') ADVANCE(38);
+      if (lookahead == 'n') ADVANCE(14);
+      END_STATE();
+    case 35:
+      if (lookahead == 'l') ADVANCE(39);
+      END_STATE();
+    case 36:
+      if (lookahead == 'n') ADVANCE(17);
+      END_STATE();
+    case 37:
+      if (lookahead == 'n') ADVANCE(21);
+      END_STATE();
+    case 38:
+      if (lookahead == 's') ADVANCE(20);
+      END_STATE();
+    case 39:
+      if (lookahead == 'u') ADVANCE(15);
       END_STATE();
     case 40:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(70);
       END_STATE();
     case 41:
-      ACCEPT_TOKEN(aux_sym__line_token1);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(40);
       END_STATE();
     case 42:
-      ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(42);
+          lookahead != '*') ADVANCE(95);
       END_STATE();
     case 43:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (eof) ADVANCE(44);
+      ADVANCE_MAP(
+        '\n', 45,
+        '!', 49,
+        '"', 74,
+        '#', 13,
+        ')', 86,
+        '*', 67,
+        ',', 85,
+        '.', 66,
+        '/', 6,
+        ':', 63,
+        '?', 69,
+        '\t', 64,
+        ' ', 64,
+      );
+      if (('-' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
       END_STATE();
     case 44:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\n') ADVANCE(49);
-      if (lookahead == '\\') ADVANCE(79);
-      if (lookahead != 0) ADVANCE(52);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 45:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(50);
-      if (lookahead == '\\') ADVANCE(45);
-      if (lookahead != 0) ADVANCE(49);
+      ACCEPT_TOKEN(aux_sym__line_token1);
       END_STATE();
     case 46:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(44);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '\r') ADVANCE(48);
+      if (lookahead == '/') ADVANCE(47);
       if (lookahead == '\\') ADVANCE(46);
-      if (lookahead != 0) ADVANCE(52);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(48);
       END_STATE();
     case 47:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(53);
-      if (lookahead == '\\') ADVANCE(47);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(49);
-      if (lookahead != 0) ADVANCE(48);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '*') ADVANCE(49);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(48);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '"') ADVANCE(49);
-      if (lookahead == '\\') ADVANCE(69);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '/') ADVANCE(47);
+      if (lookahead == '\\') ADVANCE(46);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(48);
       END_STATE();
     case 49:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(3);
+      ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(49);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(3);
-      if (lookahead != 0) ADVANCE(49);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(83);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(82);
+      if (lookahead == '\n') ADVANCE(59);
+      if (lookahead == '/') ADVANCE(56);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead != 0) ADVANCE(57);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(52);
+      if (lookahead == '\r') ADVANCE(60);
+      if (lookahead == '\\') ADVANCE(52);
+      if (lookahead != 0) ADVANCE(59);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(69);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(49);
-      if (lookahead != 0) ADVANCE(48);
+      if (lookahead == '\r') ADVANCE(58);
+      if (lookahead == '/') ADVANCE(56);
+      if (lookahead == '\\') ADVANCE(53);
+      if (lookahead != 0) ADVANCE(57);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(74);
+      if (lookahead == '\r') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(54);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(59);
+      if (lookahead != 0) ADVANCE(55);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '"') ADVANCE(59);
+      if (lookahead == '\\') ADVANCE(75);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(55);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(aux_sym_resource_token1);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '*') ADVANCE(59);
+      if (lookahead == '\\') ADVANCE(89);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(57);
       END_STATE();
     case 57:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '/') ADVANCE(56);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(57);
+      END_STATE();
+    case 58:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '/') ADVANCE(56);
+      if (lookahead == '\\') ADVANCE(92);
+      if (lookahead != 0) ADVANCE(57);
+      END_STATE();
+    case 59:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(4);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(59);
+      END_STATE();
+    case 60:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(4);
+      if (lookahead != 0) ADVANCE(59);
+      END_STATE();
+    case 61:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(75);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(59);
+      if (lookahead != 0) ADVANCE(55);
+      END_STATE();
+    case 62:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(80);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 64:
+      ACCEPT_TOKEN(aux_sym_resource_token1);
+      END_STATE();
+    case 65:
       ACCEPT_TOKEN(aux_sym_resource_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(74);
+          lookahead != '"') ADVANCE(80);
       END_STATE();
-    case 58:
+    case 66:
       ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
-    case 59:
+    case 67:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 60:
-      ACCEPT_TOKEN(sym_component);
-      if (lookahead == '-') ADVANCE(61);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      END_STATE();
-    case 61:
+    case 68:
       ACCEPT_TOKEN(sym_component);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(61);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
       END_STATE();
-    case 62:
+    case 69:
       ACCEPT_TOKEN(sym_any_component);
       END_STATE();
-    case 63:
+    case 70:
       ACCEPT_TOKEN(sym_escape_sequence);
       END_STATE();
-    case 64:
+    case 71:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       END_STATE();
-    case 65:
+    case 72:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
-      if (lookahead == '*') ADVANCE(6);
-      if (lookahead == '/') ADVANCE(49);
+      if (lookahead == '*') ADVANCE(9);
+      if (lookahead == '/') ADVANCE(59);
       END_STATE();
-    case 66:
-      ACCEPT_TOKEN(aux_sym_resource_value_token1);
-      if (lookahead == 'd') ADVANCE(15);
-      if (lookahead == 'e') ADVANCE(30);
-      if (lookahead == 'i') ADVANCE(22);
-      if (lookahead == 'u') ADVANCE(32);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(9);
-      END_STATE();
-    case 67:
+    case 73:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == ' ' ||
           lookahead == '\\' ||
-          lookahead == 'n') ADVANCE(63);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(37);
-      END_STATE();
-    case 68:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
-      END_STATE();
-    case 69:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '\r') ADVANCE(53);
-      if (lookahead == '\\') ADVANCE(47);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(49);
-      if (lookahead != 0) ADVANCE(48);
-      END_STATE();
-    case 70:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(72);
-      if (lookahead == '/') ADVANCE(48);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(74);
-      END_STATE();
-    case 71:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(71);
-      if (lookahead == '/') ADVANCE(54);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(6);
-      if (lookahead != 0) ADVANCE(72);
-      END_STATE();
-    case 72:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(71);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(6);
-      if (lookahead != 0) ADVANCE(72);
-      END_STATE();
-    case 73:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '/') ADVANCE(70);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(57);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(74);
+          lookahead == 'n') ADVANCE(70);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(41);
       END_STATE();
     case 74:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(74);
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
     case 75:
-      ACCEPT_TOKEN(aux_sym_include_directive_token1);
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '\r') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(54);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(59);
+      if (lookahead != 0) ADVANCE(55);
       END_STATE();
     case 76:
-      ACCEPT_TOKEN(aux_sym_define_directive_token1);
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '*') ADVANCE(78);
+      if (lookahead == '/') ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(80);
       END_STATE();
     case 77:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(6);
+      ACCEPT_TOKEN(aux_sym_string_token1);
       if (lookahead == '*') ADVANCE(77);
-      if (lookahead == '/') ADVANCE(51);
-      if (lookahead == '\\') ADVANCE(81);
+      if (lookahead == '/') ADVANCE(62);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(9);
       if (lookahead != 0) ADVANCE(78);
       END_STATE();
     case 78:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(6);
+      ACCEPT_TOKEN(aux_sym_string_token1);
       if (lookahead == '*') ADVANCE(77);
-      if (lookahead == '\\') ADVANCE(81);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(9);
       if (lookahead != 0) ADVANCE(78);
       END_STATE();
     case 79:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(44);
-      if (lookahead == '\\') ADVANCE(46);
-      if (lookahead != 0) ADVANCE(52);
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '/') ADVANCE(76);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(65);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(80);
       END_STATE();
     case 80:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(78);
-      if (lookahead == '/') ADVANCE(52);
-      if (lookahead == '\\') ADVANCE(83);
+      ACCEPT_TOKEN(aux_sym_string_token1);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(82);
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(80);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(77);
-      if (lookahead == '\\') ADVANCE(81);
-      if (lookahead != 0) ADVANCE(78);
+      ACCEPT_TOKEN(aux_sym_include_directive_token1);
       END_STATE();
     case 82:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\\') ADVANCE(83);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(82);
+      ACCEPT_TOKEN(aux_sym_define_directive_token1);
       END_STATE();
     case 83:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\\') ADVANCE(83);
-      if (lookahead != 0) ADVANCE(82);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 84:
-      ACCEPT_TOKEN(aux_sym_undef_directive_token1);
+      ACCEPT_TOKEN(anon_sym_DOT_DOT_DOT);
       END_STATE();
     case 85:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 86:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 87:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token3);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\n') ADVANCE(9);
+      if (lookahead == '*') ADVANCE(87);
+      if (lookahead == '/') ADVANCE(50);
+      if (lookahead == '\\') ADVANCE(91);
+      if (lookahead != 0) ADVANCE(88);
       END_STATE();
     case 88:
-      ACCEPT_TOKEN(aux_sym_else_directive_token1);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\n') ADVANCE(9);
+      if (lookahead == '*') ADVANCE(87);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(91);
+      if (lookahead != 0) ADVANCE(88);
       END_STATE();
     case 89:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\n') ADVANCE(59);
+      if (lookahead == '\r') ADVANCE(51);
+      if (lookahead == '/') ADVANCE(56);
+      if (lookahead == '\\') ADVANCE(53);
+      if (lookahead != 0) ADVANCE(57);
+      END_STATE();
+    case 90:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\r') ADVANCE(96);
+      if (lookahead == '/') ADVANCE(42);
+      if (lookahead == '\\') ADVANCE(90);
+      if (lookahead != 0) ADVANCE(95);
+      END_STATE();
+    case 91:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\r') ADVANCE(94);
+      if (lookahead == '*') ADVANCE(87);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(91);
+      if (lookahead != 0) ADVANCE(88);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\r') ADVANCE(58);
+      if (lookahead == '/') ADVANCE(56);
+      if (lookahead == '\\') ADVANCE(53);
+      if (lookahead != 0) ADVANCE(57);
+      END_STATE();
+    case 93:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '*') ADVANCE(88);
+      if (lookahead == '/') ADVANCE(56);
+      if (lookahead == '\\') ADVANCE(90);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(95);
+      END_STATE();
+    case 94:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '*') ADVANCE(87);
+      if (lookahead == '/') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(91);
+      if (lookahead != 0) ADVANCE(88);
+      END_STATE();
+    case 95:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '/') ADVANCE(42);
+      if (lookahead == '\\') ADVANCE(90);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(95);
+      END_STATE();
+    case 96:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '/') ADVANCE(42);
+      if (lookahead == '\\') ADVANCE(90);
+      if (lookahead != 0) ADVANCE(95);
+      END_STATE();
+    case 97:
+      ACCEPT_TOKEN(aux_sym_undef_directive_token1);
+      END_STATE();
+    case 98:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
+      END_STATE();
+    case 99:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
+      END_STATE();
+    case 100:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token3);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(aux_sym_else_directive_token1);
+      END_STATE();
+    case 102:
       ACCEPT_TOKEN(sym_identifier);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(102);
       END_STATE();
     default:
       return false;
@@ -928,58 +1068,66 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 39},
-  [2] = {.lex_state = 39},
-  [3] = {.lex_state = 39},
-  [4] = {.lex_state = 39},
-  [5] = {.lex_state = 39},
-  [6] = {.lex_state = 39},
-  [7] = {.lex_state = 39},
-  [8] = {.lex_state = 39},
-  [9] = {.lex_state = 39},
-  [10] = {.lex_state = 39},
-  [11] = {.lex_state = 39},
-  [12] = {.lex_state = 39},
-  [13] = {.lex_state = 39},
-  [14] = {.lex_state = 1},
-  [15] = {.lex_state = 1},
-  [16] = {.lex_state = 39},
-  [17] = {.lex_state = 39},
-  [18] = {.lex_state = 1},
-  [19] = {.lex_state = 1},
-  [20] = {.lex_state = 39},
-  [21] = {.lex_state = 39},
-  [22] = {.lex_state = 39},
-  [23] = {.lex_state = 39},
-  [24] = {.lex_state = 2},
-  [25] = {.lex_state = 39},
-  [26] = {.lex_state = 2},
-  [27] = {.lex_state = 2},
-  [28] = {.lex_state = 1},
-  [29] = {.lex_state = 39},
-  [30] = {.lex_state = 39},
-  [31] = {.lex_state = 0},
-  [32] = {.lex_state = 0},
-  [33] = {.lex_state = 39},
-  [34] = {.lex_state = 0},
-  [35] = {.lex_state = 0},
-  [36] = {.lex_state = 7},
-  [37] = {.lex_state = 0},
-  [38] = {.lex_state = 7},
-  [39] = {.lex_state = 0},
+  [1] = {.lex_state = 43},
+  [2] = {.lex_state = 43},
+  [3] = {.lex_state = 43},
+  [4] = {.lex_state = 43},
+  [5] = {.lex_state = 43},
+  [6] = {.lex_state = 43},
+  [7] = {.lex_state = 43},
+  [8] = {.lex_state = 43},
+  [9] = {.lex_state = 43},
+  [10] = {.lex_state = 43},
+  [11] = {.lex_state = 43},
+  [12] = {.lex_state = 43},
+  [13] = {.lex_state = 43},
+  [14] = {.lex_state = 3},
+  [15] = {.lex_state = 43},
+  [16] = {.lex_state = 43},
+  [17] = {.lex_state = 3},
+  [18] = {.lex_state = 43},
+  [19] = {.lex_state = 43},
+  [20] = {.lex_state = 1},
+  [21] = {.lex_state = 3},
+  [22] = {.lex_state = 3},
+  [23] = {.lex_state = 43},
+  [24] = {.lex_state = 43},
+  [25] = {.lex_state = 43},
+  [26] = {.lex_state = 43},
+  [27] = {.lex_state = 5},
+  [28] = {.lex_state = 43},
+  [29] = {.lex_state = 3},
+  [30] = {.lex_state = 43},
+  [31] = {.lex_state = 2},
+  [32] = {.lex_state = 2},
+  [33] = {.lex_state = 43},
+  [34] = {.lex_state = 5},
+  [35] = {.lex_state = 43},
+  [36] = {.lex_state = 2},
+  [37] = {.lex_state = 2},
+  [38] = {.lex_state = 5},
+  [39] = {.lex_state = 5},
   [40] = {.lex_state = 0},
-  [41] = {.lex_state = 0},
+  [41] = {.lex_state = 79},
   [42] = {.lex_state = 0},
   [43] = {.lex_state = 0},
-  [44] = {.lex_state = 39},
-  [45] = {.lex_state = 7},
-  [46] = {.lex_state = 0},
-  [47] = {.lex_state = 73},
+  [44] = {.lex_state = 0},
+  [45] = {.lex_state = 43},
+  [46] = {.lex_state = 43},
+  [47] = {.lex_state = 0},
   [48] = {.lex_state = 0},
   [49] = {.lex_state = 0},
-  [50] = {.lex_state = 0},
-  [51] = {.lex_state = 39},
+  [50] = {.lex_state = 43},
+  [51] = {.lex_state = 0},
   [52] = {.lex_state = 0},
+  [53] = {.lex_state = 0},
+  [54] = {.lex_state = 0},
+  [55] = {.lex_state = 43},
+  [56] = {.lex_state = 5},
+  [57] = {.lex_state = 0},
+  [58] = {.lex_state = 0},
+  [59] = {.lex_state = 0},
+  [60] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -994,32 +1142,26 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_STAR] = ACTIONS(1),
     [sym_component] = ACTIONS(1),
     [sym_any_component] = ACTIONS(1),
-    [sym_escape_sequence] = ACTIONS(1),
-    [aux_sym_resource_value_token1] = ACTIONS(1),
-    [anon_sym_DQUOTE] = ACTIONS(1),
-    [aux_sym_include_directive_token1] = ACTIONS(1),
-    [aux_sym_define_directive_token1] = ACTIONS(1),
-    [aux_sym_undef_directive_token1] = ACTIONS(1),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(1),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(1),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(1),
-    [aux_sym_else_directive_token1] = ACTIONS(1),
-    [sym_identifier] = ACTIONS(1),
+    [anon_sym_LPAREN] = ACTIONS(1),
+    [anon_sym_COMMA] = ACTIONS(1),
+    [anon_sym_RPAREN] = ACTIONS(1),
+    [sym_expansion] = ACTIONS(1),
   },
   [1] = {
-    [sym_resources] = STATE(39),
+    [sym_resources] = STATE(43),
     [sym__line] = STATE(8),
-    [sym__statement] = STATE(32),
-    [sym_resource] = STATE(32),
-    [sym_components] = STATE(30),
+    [sym__statement] = STATE(59),
+    [sym_resource] = STATE(59),
+    [sym_components] = STATE(46),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(32),
-    [sym_define_directive] = STATE(32),
-    [sym_undef_directive] = STATE(32),
-    [sym_ifdef_directive] = STATE(32),
+    [sym_include_directive] = STATE(59),
+    [sym_define_directive] = STATE(59),
+    [sym_define_function_directive] = STATE(59),
+    [sym_undef_directive] = STATE(59),
+    [sym_ifdef_directive] = STATE(59),
     [aux_sym_resources_repeat1] = STATE(5),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(25),
+    [aux_sym_components_repeat2] = STATE(26),
     [ts_builtin_sym_end] = ACTIONS(5),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
@@ -1037,17 +1179,18 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
   [2] = {
     [sym__line] = STATE(8),
-    [sym__statement] = STATE(32),
-    [sym_resource] = STATE(32),
-    [sym_components] = STATE(30),
+    [sym__statement] = STATE(59),
+    [sym_resource] = STATE(59),
+    [sym_components] = STATE(46),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(32),
-    [sym_define_directive] = STATE(32),
-    [sym_undef_directive] = STATE(32),
-    [sym_ifdef_directive] = STATE(32),
+    [sym_include_directive] = STATE(59),
+    [sym_define_directive] = STATE(59),
+    [sym_define_function_directive] = STATE(59),
+    [sym_undef_directive] = STATE(59),
+    [sym_ifdef_directive] = STATE(59),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(25),
+    [aux_sym_components_repeat2] = STATE(26),
     [ts_builtin_sym_end] = ACTIONS(25),
     [aux_sym__line_token1] = ACTIONS(27),
     [sym_comment] = ACTIONS(30),
@@ -1067,18 +1210,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
   [3] = {
     [sym__line] = STATE(8),
-    [sym__statement] = STATE(32),
-    [sym_resource] = STATE(32),
-    [sym_components] = STATE(30),
+    [sym__statement] = STATE(59),
+    [sym_resource] = STATE(59),
+    [sym_components] = STATE(46),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(32),
-    [sym_define_directive] = STATE(32),
-    [sym_undef_directive] = STATE(32),
-    [sym_ifdef_directive] = STATE(32),
-    [sym_else_directive] = STATE(51),
-    [aux_sym_resources_repeat1] = STATE(2),
+    [sym_include_directive] = STATE(59),
+    [sym_define_directive] = STATE(59),
+    [sym_define_function_directive] = STATE(59),
+    [sym_undef_directive] = STATE(59),
+    [sym_ifdef_directive] = STATE(59),
+    [sym_else_directive] = STATE(50),
+    [aux_sym_resources_repeat1] = STATE(4),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(25),
+    [aux_sym_components_repeat2] = STATE(26),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1097,18 +1241,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
   [4] = {
     [sym__line] = STATE(8),
-    [sym__statement] = STATE(32),
-    [sym_resource] = STATE(32),
-    [sym_components] = STATE(30),
+    [sym__statement] = STATE(59),
+    [sym_resource] = STATE(59),
+    [sym_components] = STATE(46),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(32),
-    [sym_define_directive] = STATE(32),
-    [sym_undef_directive] = STATE(32),
-    [sym_ifdef_directive] = STATE(32),
-    [sym_else_directive] = STATE(44),
-    [aux_sym_resources_repeat1] = STATE(3),
+    [sym_include_directive] = STATE(59),
+    [sym_define_directive] = STATE(59),
+    [sym_define_function_directive] = STATE(59),
+    [sym_undef_directive] = STATE(59),
+    [sym_ifdef_directive] = STATE(59),
+    [sym_else_directive] = STATE(55),
+    [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(25),
+    [aux_sym_components_repeat2] = STATE(26),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1127,17 +1272,18 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
   [5] = {
     [sym__line] = STATE(8),
-    [sym__statement] = STATE(32),
-    [sym_resource] = STATE(32),
-    [sym_components] = STATE(30),
+    [sym__statement] = STATE(59),
+    [sym_resource] = STATE(59),
+    [sym_components] = STATE(46),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(32),
-    [sym_define_directive] = STATE(32),
-    [sym_undef_directive] = STATE(32),
-    [sym_ifdef_directive] = STATE(32),
+    [sym_include_directive] = STATE(59),
+    [sym_define_directive] = STATE(59),
+    [sym_define_function_directive] = STATE(59),
+    [sym_undef_directive] = STATE(59),
+    [sym_ifdef_directive] = STATE(59),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(25),
+    [aux_sym_components_repeat2] = STATE(26),
     [ts_builtin_sym_end] = ACTIONS(60),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
@@ -1155,17 +1301,18 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
   [6] = {
     [sym__line] = STATE(8),
-    [sym__statement] = STATE(32),
-    [sym_resource] = STATE(32),
-    [sym_components] = STATE(30),
+    [sym__statement] = STATE(59),
+    [sym_resource] = STATE(59),
+    [sym_components] = STATE(46),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(32),
-    [sym_define_directive] = STATE(32),
-    [sym_undef_directive] = STATE(32),
-    [sym_ifdef_directive] = STATE(32),
-    [aux_sym_resources_repeat1] = STATE(2),
+    [sym_include_directive] = STATE(59),
+    [sym_define_directive] = STATE(59),
+    [sym_define_function_directive] = STATE(59),
+    [sym_undef_directive] = STATE(59),
+    [sym_ifdef_directive] = STATE(59),
+    [aux_sym_resources_repeat1] = STATE(7),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(25),
+    [aux_sym_components_repeat2] = STATE(26),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1183,17 +1330,18 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
   [7] = {
     [sym__line] = STATE(8),
-    [sym__statement] = STATE(32),
-    [sym_resource] = STATE(32),
-    [sym_components] = STATE(30),
+    [sym__statement] = STATE(59),
+    [sym_resource] = STATE(59),
+    [sym_components] = STATE(46),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(32),
-    [sym_define_directive] = STATE(32),
-    [sym_undef_directive] = STATE(32),
-    [sym_ifdef_directive] = STATE(32),
-    [aux_sym_resources_repeat1] = STATE(6),
+    [sym_include_directive] = STATE(59),
+    [sym_define_directive] = STATE(59),
+    [sym_define_function_directive] = STATE(59),
+    [sym_undef_directive] = STATE(59),
+    [sym_ifdef_directive] = STATE(59),
+    [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(25),
+    [aux_sym_components_repeat2] = STATE(26),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1255,7 +1403,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_any_component,
     ACTIONS(70), 1,
       sym_component,
-    STATE(22), 1,
+    STATE(25), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1263,33 +1411,33 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(11), 2,
+    STATE(12), 2,
       sym_binding,
       aux_sym_components_repeat1,
   [64] = 4,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(72), 2,
+    ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    ACTIONS(75), 2,
+    ACTIONS(72), 2,
       sym_component,
       sym_any_component,
-    STATE(11), 2,
+    STATE(12), 2,
       sym_binding,
       aux_sym_components_repeat1,
   [81] = 4,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(11), 2,
+    ACTIONS(74), 2,
       anon_sym_DOT,
       anon_sym_STAR,
     ACTIONS(77), 2,
       sym_component,
       sym_any_component,
-    STATE(11), 2,
+    STATE(12), 2,
       sym_binding,
       aux_sym_components_repeat1,
   [98] = 4,
@@ -1301,7 +1449,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(12), 2,
+    STATE(11), 2,
       sym_binding,
       aux_sym_components_repeat1,
   [114] = 7,
@@ -1313,28 +1461,25 @@ static const uint16_t ts_small_parse_table[] = {
       sym_escape_sequence,
     ACTIONS(85), 1,
       aux_sym_resource_value_token1,
-    STATE(19), 1,
-      aux_sym_resource_value_repeat1,
-    STATE(28), 1,
+    STATE(17), 1,
       aux_sym_resource_repeat1,
-    STATE(46), 1,
+    STATE(21), 1,
+      aux_sym_resource_value_repeat1,
+    STATE(40), 1,
       sym_resource_value,
-  [136] = 7,
-    ACTIONS(3), 1,
-      sym_preprocessor_comment,
-    ACTIONS(83), 1,
-      sym_escape_sequence,
-    ACTIONS(85), 1,
-      aux_sym_resource_value_token1,
+  [136] = 4,
     ACTIONS(87), 1,
+      anon_sym_COLON,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
       aux_sym_resource_token1,
-    STATE(14), 1,
-      aux_sym_resource_repeat1,
-    STATE(19), 1,
-      aux_sym_resource_value_repeat1,
-    STATE(37), 1,
-      sym_resource_value,
-  [158] = 4,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    STATE(11), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [152] = 4,
     ACTIONS(89), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
@@ -1343,95 +1488,109 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(12), 2,
+    STATE(11), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [174] = 4,
+  [168] = 7,
+    ACTIONS(3), 1,
+      sym_preprocessor_comment,
+    ACTIONS(83), 1,
+      sym_escape_sequence,
+    ACTIONS(85), 1,
+      aux_sym_resource_value_token1,
     ACTIONS(91), 1,
-      anon_sym_COLON,
+      aux_sym_resource_token1,
+    STATE(21), 1,
+      aux_sym_resource_value_repeat1,
+    STATE(29), 1,
+      aux_sym_resource_repeat1,
+    STATE(58), 1,
+      sym_resource_value,
+  [190] = 3,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
     ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
-    STATE(12), 2,
+    STATE(11), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [190] = 5,
-    ACTIONS(93), 1,
-      aux_sym__line_token1,
-    ACTIONS(95), 1,
-      sym_escape_sequence,
-    ACTIONS(98), 1,
-      aux_sym_resource_value_token1,
-    STATE(18), 1,
-      aux_sym_resource_value_repeat1,
+  [203] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [207] = 5,
+    ACTIONS(93), 4,
+      anon_sym_DOT,
+      anon_sym_STAR,
+      sym_component,
+      sym_any_component,
+  [214] = 5,
+    ACTIONS(95), 1,
+      aux_sym__line_token1,
+    ACTIONS(97), 1,
+      anon_sym_LPAREN,
+    ACTIONS(99), 1,
+      sym_expansion,
+    STATE(32), 1,
+      sym_parameters,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [231] = 5,
     ACTIONS(101), 1,
       aux_sym__line_token1,
     ACTIONS(103), 1,
       sym_escape_sequence,
     ACTIONS(105), 1,
       aux_sym_resource_value_token1,
-    STATE(18), 1,
+    STATE(22), 1,
       aux_sym_resource_value_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [224] = 2,
+  [248] = 5,
+    ACTIONS(107), 1,
+      aux_sym__line_token1,
+    ACTIONS(109), 1,
+      sym_escape_sequence,
+    ACTIONS(112), 1,
+      aux_sym_resource_value_token1,
+    STATE(22), 1,
+      aux_sym_resource_value_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(107), 4,
-      anon_sym_DOT,
-      anon_sym_STAR,
+  [265] = 3,
+    STATE(23), 1,
+      aux_sym_components_repeat2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(115), 2,
       sym_component,
       sym_any_component,
-  [235] = 3,
+  [277] = 4,
+    ACTIONS(118), 1,
+      anon_sym_COMMA,
+    ACTIONS(121), 1,
+      anon_sym_RPAREN,
+    STATE(24), 1,
+      aux_sym_parameters_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    STATE(12), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [248] = 4,
+  [291] = 4,
     ACTIONS(15), 1,
       sym_any_component,
-    ACTIONS(109), 1,
+    ACTIONS(123), 1,
       sym_component,
     STATE(23), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [262] = 3,
-    STATE(23), 1,
-      aux_sym_components_repeat2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(111), 2,
-      sym_component,
-      sym_any_component,
-  [274] = 5,
-    ACTIONS(114), 1,
-      aux_sym__line_token1,
-    ACTIONS(116), 1,
-      sym_preprocessor_comment,
-    ACTIONS(118), 1,
-      aux_sym_resource_token1,
-    ACTIONS(120), 1,
-      sym_expansion,
-    STATE(26), 1,
-      aux_sym_resource_repeat1,
-  [290] = 4,
+  [305] = 4,
     ACTIONS(15), 1,
       sym_any_component,
     ACTIONS(70), 1,
@@ -1441,181 +1600,234 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [304] = 5,
-    ACTIONS(116), 1,
-      sym_preprocessor_comment,
-    ACTIONS(122), 1,
-      aux_sym__line_token1,
-    ACTIONS(124), 1,
-      aux_sym_resource_token1,
+  [319] = 3,
     ACTIONS(127), 1,
-      sym_expansion,
-    STATE(26), 1,
-      aux_sym_resource_repeat1,
-  [320] = 5,
-    ACTIONS(116), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
       sym_preprocessor_comment,
-    ACTIONS(129), 1,
-      aux_sym__line_token1,
-    ACTIONS(131), 1,
       aux_sym_resource_token1,
-    ACTIONS(133), 1,
-      sym_expansion,
-    STATE(24), 1,
-      aux_sym_resource_repeat1,
-  [336] = 5,
+    ACTIONS(125), 2,
+      anon_sym_DOT_DOT_DOT,
+      sym_identifier,
+  [331] = 4,
+    ACTIONS(129), 1,
+      anon_sym_COMMA,
+    ACTIONS(131), 1,
+      anon_sym_RPAREN,
+    STATE(30), 1,
+      aux_sym_parameters_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [345] = 5,
     ACTIONS(3), 1,
       sym_preprocessor_comment,
-    ACTIONS(122), 1,
-      sym_escape_sequence,
-    ACTIONS(127), 1,
-      aux_sym_resource_value_token1,
-    ACTIONS(135), 1,
+    ACTIONS(133), 1,
       aux_sym_resource_token1,
-    STATE(28), 1,
-      aux_sym_resource_repeat1,
-  [352] = 3,
+    ACTIONS(136), 1,
+      sym_escape_sequence,
     ACTIONS(138), 1,
+      aux_sym_resource_value_token1,
+    STATE(29), 1,
+      aux_sym_resource_repeat1,
+  [361] = 4,
+    ACTIONS(129), 1,
+      anon_sym_COMMA,
+    ACTIONS(140), 1,
+      anon_sym_RPAREN,
+    STATE(24), 1,
+      aux_sym_parameters_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [375] = 3,
+    ACTIONS(142), 1,
+      aux_sym__line_token1,
+    ACTIONS(144), 1,
+      sym_expansion,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [386] = 3,
+    ACTIONS(146), 1,
+      aux_sym__line_token1,
+    ACTIONS(148), 1,
+      sym_expansion,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [397] = 2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(121), 2,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+  [406] = 2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(150), 2,
+      anon_sym_DOT_DOT_DOT,
+      sym_identifier,
+  [415] = 3,
+    ACTIONS(152), 1,
       anon_sym_DQUOTE,
-    STATE(48), 1,
+    STATE(42), 1,
       sym_string,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [363] = 2,
-    ACTIONS(140), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [371] = 2,
-    ACTIONS(142), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [379] = 2,
-    ACTIONS(144), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [387] = 2,
-    ACTIONS(146), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [395] = 2,
-    ACTIONS(148), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [403] = 2,
-    ACTIONS(150), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [411] = 2,
-    ACTIONS(152), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [419] = 2,
+  [426] = 3,
     ACTIONS(154), 1,
       aux_sym__line_token1,
+    ACTIONS(156), 1,
+      sym_expansion,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [427] = 2,
-    ACTIONS(156), 1,
+  [437] = 3,
+    ACTIONS(158), 1,
+      aux_sym__line_token1,
+    ACTIONS(160), 1,
+      sym_expansion,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [448] = 2,
+    ACTIONS(162), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [435] = 2,
-    ACTIONS(158), 1,
-      ts_builtin_sym_end,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [443] = 2,
-    ACTIONS(160), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [451] = 2,
-    ACTIONS(162), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [459] = 2,
+  [456] = 2,
     ACTIONS(164), 1,
-      aux_sym__line_token1,
+      sym_identifier,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [467] = 2,
+  [464] = 2,
     ACTIONS(166), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [475] = 2,
-    ACTIONS(168), 1,
-      aux_sym_ifdef_directive_token3,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [483] = 2,
+  [472] = 2,
     ACTIONS(170), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
+      aux_sym_string_token1,
+    ACTIONS(168), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [491] = 2,
+  [480] = 2,
     ACTIONS(172), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [499] = 2,
+  [488] = 2,
     ACTIONS(174), 1,
-      aux_sym_string_token1,
-    ACTIONS(116), 2,
+      ts_builtin_sym_end,
+    ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [507] = 2,
+  [496] = 2,
     ACTIONS(176), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [515] = 2,
+  [504] = 2,
     ACTIONS(178), 1,
-      aux_sym__line_token1,
+      anon_sym_DQUOTE,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [523] = 2,
+  [512] = 2,
     ACTIONS(180), 1,
+      anon_sym_COLON,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [520] = 2,
+    ACTIONS(182), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [531] = 2,
-    ACTIONS(182), 1,
+  [528] = 2,
+    ACTIONS(184), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [536] = 2,
+    ACTIONS(186), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [544] = 2,
+    ACTIONS(188), 1,
       aux_sym_ifdef_directive_token3,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [539] = 2,
-    ACTIONS(184), 1,
+  [552] = 2,
+    ACTIONS(190), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [560] = 2,
+    ACTIONS(192), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [568] = 2,
+    ACTIONS(194), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [576] = 2,
+    ACTIONS(196), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [584] = 2,
+    ACTIONS(198), 1,
+      aux_sym_ifdef_directive_token3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [592] = 2,
+    ACTIONS(200), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [600] = 2,
+    ACTIONS(202), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [608] = 2,
+    ACTIONS(204), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [616] = 2,
+    ACTIONS(206), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [624] = 2,
+    ACTIONS(208), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1631,43 +1843,51 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(13)] = 98,
   [SMALL_STATE(14)] = 114,
   [SMALL_STATE(15)] = 136,
-  [SMALL_STATE(16)] = 158,
-  [SMALL_STATE(17)] = 174,
+  [SMALL_STATE(16)] = 152,
+  [SMALL_STATE(17)] = 168,
   [SMALL_STATE(18)] = 190,
-  [SMALL_STATE(19)] = 207,
-  [SMALL_STATE(20)] = 224,
-  [SMALL_STATE(21)] = 235,
+  [SMALL_STATE(19)] = 203,
+  [SMALL_STATE(20)] = 214,
+  [SMALL_STATE(21)] = 231,
   [SMALL_STATE(22)] = 248,
-  [SMALL_STATE(23)] = 262,
-  [SMALL_STATE(24)] = 274,
-  [SMALL_STATE(25)] = 290,
-  [SMALL_STATE(26)] = 304,
-  [SMALL_STATE(27)] = 320,
-  [SMALL_STATE(28)] = 336,
-  [SMALL_STATE(29)] = 352,
-  [SMALL_STATE(30)] = 363,
-  [SMALL_STATE(31)] = 371,
-  [SMALL_STATE(32)] = 379,
-  [SMALL_STATE(33)] = 387,
-  [SMALL_STATE(34)] = 395,
-  [SMALL_STATE(35)] = 403,
-  [SMALL_STATE(36)] = 411,
-  [SMALL_STATE(37)] = 419,
-  [SMALL_STATE(38)] = 427,
-  [SMALL_STATE(39)] = 435,
-  [SMALL_STATE(40)] = 443,
-  [SMALL_STATE(41)] = 451,
-  [SMALL_STATE(42)] = 459,
-  [SMALL_STATE(43)] = 467,
-  [SMALL_STATE(44)] = 475,
-  [SMALL_STATE(45)] = 483,
-  [SMALL_STATE(46)] = 491,
-  [SMALL_STATE(47)] = 499,
-  [SMALL_STATE(48)] = 507,
-  [SMALL_STATE(49)] = 515,
-  [SMALL_STATE(50)] = 523,
-  [SMALL_STATE(51)] = 531,
-  [SMALL_STATE(52)] = 539,
+  [SMALL_STATE(23)] = 265,
+  [SMALL_STATE(24)] = 277,
+  [SMALL_STATE(25)] = 291,
+  [SMALL_STATE(26)] = 305,
+  [SMALL_STATE(27)] = 319,
+  [SMALL_STATE(28)] = 331,
+  [SMALL_STATE(29)] = 345,
+  [SMALL_STATE(30)] = 361,
+  [SMALL_STATE(31)] = 375,
+  [SMALL_STATE(32)] = 386,
+  [SMALL_STATE(33)] = 397,
+  [SMALL_STATE(34)] = 406,
+  [SMALL_STATE(35)] = 415,
+  [SMALL_STATE(36)] = 426,
+  [SMALL_STATE(37)] = 437,
+  [SMALL_STATE(38)] = 448,
+  [SMALL_STATE(39)] = 456,
+  [SMALL_STATE(40)] = 464,
+  [SMALL_STATE(41)] = 472,
+  [SMALL_STATE(42)] = 480,
+  [SMALL_STATE(43)] = 488,
+  [SMALL_STATE(44)] = 496,
+  [SMALL_STATE(45)] = 504,
+  [SMALL_STATE(46)] = 512,
+  [SMALL_STATE(47)] = 520,
+  [SMALL_STATE(48)] = 528,
+  [SMALL_STATE(49)] = 536,
+  [SMALL_STATE(50)] = 544,
+  [SMALL_STATE(51)] = 552,
+  [SMALL_STATE(52)] = 560,
+  [SMALL_STATE(53)] = 568,
+  [SMALL_STATE(54)] = 576,
+  [SMALL_STATE(55)] = 584,
+  [SMALL_STATE(56)] = 592,
+  [SMALL_STATE(57)] = 600,
+  [SMALL_STATE(58)] = 608,
+  [SMALL_STATE(59)] = 616,
+  [SMALL_STATE(60)] = 624,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -1676,87 +1896,99 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 0, 0, 0),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
   [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
   [27] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(8),
-  [30] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
-  [33] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(20),
-  [36] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
-  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
-  [42] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(29),
-  [45] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(36),
-  [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(38),
-  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(45),
-  [54] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [56] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [30] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(59),
+  [33] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
+  [36] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(13),
+  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
+  [42] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(35),
+  [45] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(38),
+  [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(56),
+  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(39),
+  [54] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [56] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
   [60] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
-  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
-  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
+  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
+  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
   [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
   [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
-  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [72] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(20),
-  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
-  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
-  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
-  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [83] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [85] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [87] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
+  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
+  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
+  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
+  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [83] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [85] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
+  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
   [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
-  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
-  [95] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
-  [98] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
+  [91] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
+  [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [99] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
   [101] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
-  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [105] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
-  [109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [111] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(21),
-  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 2),
-  [116] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [124] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(26),
-  [127] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
-  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [133] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [135] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
-  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_undef_directive, 2, 0, 2),
-  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
-  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 4),
-  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [158] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [160] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
-  [162] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 4, 0, 5),
-  [164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 6),
-  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 7),
-  [174] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
-  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 8),
-  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 9),
-  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 10),
+  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [105] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
+  [109] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(22),
+  [112] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(22),
+  [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(18),
+  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0), SHIFT_REPEAT(34),
+  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_parameters_repeat1, 2, 0, 0),
+  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [133] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(29),
+  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [138] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 2, 0, 0),
+  [144] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 2, 0, 0),
+  [146] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 3, 0, 4),
+  [148] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
+  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 3, 0, 0),
+  [156] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 3, 0, 0),
+  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 4, 0, 0),
+  [160] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parameters, 4, 0, 0),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 5),
+  [168] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [170] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
+  [174] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
+  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [182] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_function_directive, 4, 0, 6),
+  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 7),
+  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_undef_directive, 2, 0, 2),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 9),
+  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 10),
+  [198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
+  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 8),
+  [206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 11),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,11 +5,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 51
+#define STATE_COUNT 53
 #define LARGE_STATE_COUNT 8
-#define SYMBOL_COUNT 39
+#define SYMBOL_COUNT 41
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 22
+#define TOKEN_COUNT 23
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 6
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
@@ -32,29 +32,31 @@ enum ts_symbol_identifiers {
   aux_sym_include_directive_token1 = 14,
   aux_sym_define_directive_token1 = 15,
   sym_expansion = 16,
-  aux_sym_ifdef_directive_token1 = 17,
-  aux_sym_ifdef_directive_token2 = 18,
-  aux_sym_ifdef_directive_token3 = 19,
-  aux_sym_else_directive_token1 = 20,
-  sym_identifier = 21,
-  sym_resources = 22,
-  sym__line = 23,
-  sym__statement = 24,
-  sym_resource = 25,
-  sym_components = 26,
-  sym_binding = 27,
-  sym_resource_value = 28,
-  sym_string = 29,
-  sym_include_directive = 30,
-  sym_define_directive = 31,
-  sym_ifdef_directive = 32,
-  sym_else_directive = 33,
-  aux_sym_resources_repeat1 = 34,
-  aux_sym_resource_repeat1 = 35,
-  aux_sym_components_repeat1 = 36,
-  aux_sym_components_repeat2 = 37,
-  aux_sym_resource_value_repeat1 = 38,
-  alias_sym_body = 39,
+  aux_sym_undef_directive_token1 = 17,
+  aux_sym_ifdef_directive_token1 = 18,
+  aux_sym_ifdef_directive_token2 = 19,
+  aux_sym_ifdef_directive_token3 = 20,
+  aux_sym_else_directive_token1 = 21,
+  sym_identifier = 22,
+  sym_resources = 23,
+  sym__line = 24,
+  sym__statement = 25,
+  sym_resource = 26,
+  sym_components = 27,
+  sym_binding = 28,
+  sym_resource_value = 29,
+  sym_string = 30,
+  sym_include_directive = 31,
+  sym_define_directive = 32,
+  sym_undef_directive = 33,
+  sym_ifdef_directive = 34,
+  sym_else_directive = 35,
+  aux_sym_resources_repeat1 = 36,
+  aux_sym_resource_repeat1 = 37,
+  aux_sym_components_repeat1 = 38,
+  aux_sym_components_repeat2 = 39,
+  aux_sym_resource_value_repeat1 = 40,
+  alias_sym_body = 41,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -75,6 +77,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_include_directive_token1] = "#include",
   [aux_sym_define_directive_token1] = "#define",
   [sym_expansion] = "expansion",
+  [aux_sym_undef_directive_token1] = "#undef",
   [aux_sym_ifdef_directive_token1] = "#ifdef",
   [aux_sym_ifdef_directive_token2] = "#ifndef",
   [aux_sym_ifdef_directive_token3] = "#endif",
@@ -90,6 +93,7 @@ static const char * const ts_symbol_names[] = {
   [sym_string] = "string",
   [sym_include_directive] = "include_directive",
   [sym_define_directive] = "define_directive",
+  [sym_undef_directive] = "undef_directive",
   [sym_ifdef_directive] = "ifdef_directive",
   [sym_else_directive] = "else_directive",
   [aux_sym_resources_repeat1] = "resources_repeat1",
@@ -118,6 +122,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_include_directive_token1] = aux_sym_include_directive_token1,
   [aux_sym_define_directive_token1] = aux_sym_define_directive_token1,
   [sym_expansion] = sym_expansion,
+  [aux_sym_undef_directive_token1] = aux_sym_undef_directive_token1,
   [aux_sym_ifdef_directive_token1] = aux_sym_ifdef_directive_token1,
   [aux_sym_ifdef_directive_token2] = aux_sym_ifdef_directive_token2,
   [aux_sym_ifdef_directive_token3] = aux_sym_ifdef_directive_token3,
@@ -133,6 +138,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_string] = sym_string,
   [sym_include_directive] = sym_include_directive,
   [sym_define_directive] = sym_define_directive,
+  [sym_undef_directive] = sym_undef_directive,
   [sym_ifdef_directive] = sym_ifdef_directive,
   [sym_else_directive] = sym_else_directive,
   [aux_sym_resources_repeat1] = aux_sym_resources_repeat1,
@@ -212,6 +218,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [aux_sym_undef_directive_token1] = {
+    .visible = true,
+    .named = false,
+  },
   [aux_sym_ifdef_directive_token1] = {
     .visible = true,
     .named = false,
@@ -269,6 +279,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
   },
   [sym_define_directive] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_undef_directive] = {
     .visible = true,
     .named = true,
   },
@@ -415,7 +429,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [25] = 25,
   [26] = 26,
   [27] = 27,
-  [28] = 27,
+  [28] = 26,
   [29] = 29,
   [30] = 30,
   [31] = 31,
@@ -438,6 +452,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [48] = 48,
   [49] = 49,
   [50] = 50,
+  [51] = 51,
+  [52] = 52,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -445,55 +461,55 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(36);
+      if (eof) ADVANCE(40);
       ADVANCE_MAP(
-        '\n', 37,
-        '!', 38,
-        '"', 64,
-        '#', 62,
-        '*', 55,
-        '.', 54,
-        '/', 61,
-        ':', 51,
-        '?', 58,
-        '\\', 63,
-        '\t', 52,
-        ' ', 52,
+        '\n', 41,
+        '!', 42,
+        '"', 68,
+        '#', 66,
+        '*', 59,
+        '.', 58,
+        '/', 65,
+        ':', 55,
+        '?', 62,
+        '\\', 67,
+        '\t', 56,
+        ' ', 56,
       );
-      if (('-' <= lookahead && lookahead <= '9')) ADVANCE(57);
+      if (('-' <= lookahead && lookahead <= '9')) ADVANCE(61);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
-      if (lookahead != 0) ADVANCE(60);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
+      if (lookahead != 0) ADVANCE(64);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(37);
-      if (lookahead == '/') ADVANCE(61);
-      if (lookahead == '\\') ADVANCE(63);
+      if (lookahead == '\n') ADVANCE(41);
+      if (lookahead == '/') ADVANCE(65);
+      if (lookahead == '\\') ADVANCE(67);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(52);
-      if (lookahead != 0) ADVANCE(60);
+          lookahead == ' ') ADVANCE(56);
+      if (lookahead != 0) ADVANCE(64);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(37);
-      if (lookahead == '/') ADVANCE(76);
+      if (lookahead == '\n') ADVANCE(41);
+      if (lookahead == '/') ADVANCE(80);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(52);
+          lookahead == ' ') ADVANCE(56);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(78);
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(82);
       END_STATE();
     case 3:
-      if (lookahead == '\r') ADVANCE(46);
-      if (lookahead == '\\') ADVANCE(41);
-      if (lookahead != 0) ADVANCE(45);
+      if (lookahead == '\r') ADVANCE(50);
+      if (lookahead == '\\') ADVANCE(45);
+      if (lookahead != 0) ADVANCE(49);
       END_STATE();
     case 4:
       if (lookahead == '*') ADVANCE(6);
-      if (lookahead == '/') ADVANCE(45);
+      if (lookahead == '/') ADVANCE(49);
       END_STATE();
     case 5:
       if (lookahead == '*') ADVANCE(5);
-      if (lookahead == '/') ADVANCE(39);
+      if (lookahead == '/') ADVANCE(43);
       if (lookahead != 0) ADVANCE(6);
       END_STATE();
     case 6:
@@ -503,390 +519,407 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 7:
       if (lookahead == '/') ADVANCE(4);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(52);
+          lookahead == ' ') ADVANCE(56);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(34);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(38);
       END_STATE();
     case 8:
-      if (lookahead == 'c') ADVANCE(28);
+      if (lookahead == 'c') ADVANCE(31);
       END_STATE();
     case 9:
-      if (lookahead == 'd') ADVANCE(14);
-      if (lookahead == 'e') ADVANCE(27);
-      if (lookahead == 'i') ADVANCE(20);
+      if (lookahead == 'd') ADVANCE(15);
+      if (lookahead == 'e') ADVANCE(30);
+      if (lookahead == 'i') ADVANCE(22);
+      if (lookahead == 'u') ADVANCE(32);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(9);
       END_STATE();
     case 10:
-      if (lookahead == 'd') ADVANCE(26);
+      if (lookahead == 'd') ADVANCE(29);
       END_STATE();
     case 11:
-      if (lookahead == 'd') ADVANCE(17);
+      if (lookahead == 'd') ADVANCE(18);
       END_STATE();
     case 12:
-      if (lookahead == 'd') ADVANCE(18);
-      if (lookahead == 'n') ADVANCE(13);
+      if (lookahead == 'd') ADVANCE(19);
+      if (lookahead == 'n') ADVANCE(14);
       END_STATE();
     case 13:
-      if (lookahead == 'd') ADVANCE(19);
+      if (lookahead == 'd') ADVANCE(20);
       END_STATE();
     case 14:
-      if (lookahead == 'e') ADVANCE(21);
+      if (lookahead == 'd') ADVANCE(21);
       END_STATE();
     case 15:
-      if (lookahead == 'e') ADVANCE(83);
-      END_STATE();
-    case 16:
-      if (lookahead == 'e') ADVANCE(72);
-      END_STATE();
-    case 17:
-      if (lookahead == 'e') ADVANCE(71);
-      END_STATE();
-    case 18:
       if (lookahead == 'e') ADVANCE(23);
       END_STATE();
+    case 16:
+      if (lookahead == 'e') ADVANCE(88);
+      END_STATE();
+    case 17:
+      if (lookahead == 'e') ADVANCE(76);
+      END_STATE();
+    case 18:
+      if (lookahead == 'e') ADVANCE(75);
+      END_STATE();
     case 19:
-      if (lookahead == 'e') ADVANCE(24);
+      if (lookahead == 'e') ADVANCE(25);
       END_STATE();
     case 20:
+      if (lookahead == 'e') ADVANCE(26);
+      END_STATE();
+    case 21:
+      if (lookahead == 'e') ADVANCE(27);
+      END_STATE();
+    case 22:
       if (lookahead == 'f') ADVANCE(12);
       if (lookahead == 'n') ADVANCE(8);
       END_STATE();
-    case 21:
-      if (lookahead == 'f') ADVANCE(25);
-      END_STATE();
-    case 22:
-      if (lookahead == 'f') ADVANCE(82);
-      END_STATE();
     case 23:
-      if (lookahead == 'f') ADVANCE(80);
+      if (lookahead == 'f') ADVANCE(28);
       END_STATE();
     case 24:
-      if (lookahead == 'f') ADVANCE(81);
+      if (lookahead == 'f') ADVANCE(87);
       END_STATE();
     case 25:
-      if (lookahead == 'i') ADVANCE(29);
+      if (lookahead == 'f') ADVANCE(85);
       END_STATE();
     case 26:
-      if (lookahead == 'i') ADVANCE(22);
+      if (lookahead == 'f') ADVANCE(84);
       END_STATE();
     case 27:
-      if (lookahead == 'l') ADVANCE(30);
-      if (lookahead == 'n') ADVANCE(10);
+      if (lookahead == 'f') ADVANCE(86);
       END_STATE();
     case 28:
-      if (lookahead == 'l') ADVANCE(31);
+      if (lookahead == 'i') ADVANCE(33);
       END_STATE();
     case 29:
-      if (lookahead == 'n') ADVANCE(16);
+      if (lookahead == 'i') ADVANCE(24);
       END_STATE();
     case 30:
-      if (lookahead == 's') ADVANCE(15);
+      if (lookahead == 'l') ADVANCE(34);
+      if (lookahead == 'n') ADVANCE(10);
       END_STATE();
     case 31:
-      if (lookahead == 'u') ADVANCE(11);
+      if (lookahead == 'l') ADVANCE(35);
       END_STATE();
     case 32:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(59);
+      if (lookahead == 'n') ADVANCE(13);
       END_STATE();
     case 33:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(32);
+      if (lookahead == 'n') ADVANCE(17);
       END_STATE();
     case 34:
+      if (lookahead == 's') ADVANCE(16);
+      END_STATE();
+    case 35:
+      if (lookahead == 'u') ADVANCE(11);
+      END_STATE();
+    case 36:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(63);
+      END_STATE();
+    case 37:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(36);
+      END_STATE();
+    case 38:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
-    case 35:
-      if (eof) ADVANCE(36);
+    case 39:
+      if (eof) ADVANCE(40);
       ADVANCE_MAP(
-        '\n', 37,
-        '!', 38,
-        '"', 64,
+        '\n', 41,
+        '!', 42,
+        '"', 68,
         '#', 9,
-        '*', 55,
-        '.', 54,
+        '*', 59,
+        '.', 58,
         '/', 4,
-        ':', 51,
-        '?', 58,
-        '\t', 52,
-        ' ', 52,
+        ':', 55,
+        '?', 62,
+        '\t', 56,
+        ' ', 56,
       );
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(57);
-      END_STATE();
-    case 36:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 37:
-      ACCEPT_TOKEN(aux_sym__line_token1);
-      END_STATE();
-    case 38:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(38);
-      END_STATE();
-    case 39:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(61);
       END_STATE();
     case 40:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\n') ADVANCE(45);
-      if (lookahead == '\\') ADVANCE(75);
-      if (lookahead != 0) ADVANCE(48);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 41:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(46);
-      if (lookahead == '\\') ADVANCE(41);
-      if (lookahead != 0) ADVANCE(45);
+      ACCEPT_TOKEN(aux_sym__line_token1);
       END_STATE();
     case 42:
-      ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(40);
-      if (lookahead == '\\') ADVANCE(42);
-      if (lookahead != 0) ADVANCE(48);
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(42);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(49);
-      if (lookahead == '\\') ADVANCE(43);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(45);
-      if (lookahead != 0) ADVANCE(44);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '"') ADVANCE(45);
-      if (lookahead == '\\') ADVANCE(65);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(44);
+      if (lookahead == '\n') ADVANCE(49);
+      if (lookahead == '\\') ADVANCE(79);
+      if (lookahead != 0) ADVANCE(52);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(3);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(45);
+      if (lookahead == '\r') ADVANCE(50);
+      if (lookahead == '\\') ADVANCE(45);
+      if (lookahead != 0) ADVANCE(49);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(3);
-      if (lookahead != 0) ADVANCE(45);
+      if (lookahead == '\r') ADVANCE(44);
+      if (lookahead == '\\') ADVANCE(46);
+      if (lookahead != 0) ADVANCE(52);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(78);
+      if (lookahead == '\r') ADVANCE(53);
+      if (lookahead == '\\') ADVANCE(47);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(49);
+      if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(75);
+      if (lookahead == '"') ADVANCE(49);
+      if (lookahead == '\\') ADVANCE(69);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(48);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(65);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(45);
-      if (lookahead != 0) ADVANCE(44);
+      if (lookahead == '\\') ADVANCE(3);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(49);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(70);
+      if (lookahead == '\\') ADVANCE(3);
+      if (lookahead != 0) ADVANCE(49);
       END_STATE();
     case 51:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(83);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(82);
       END_STATE();
     case 52:
-      ACCEPT_TOKEN(aux_sym_resource_token1);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(79);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(52);
       END_STATE();
     case 53:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(69);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(49);
+      if (lookahead != 0) ADVANCE(48);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(74);
+      END_STATE();
+    case 55:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 56:
+      ACCEPT_TOKEN(aux_sym_resource_token1);
+      END_STATE();
+    case 57:
       ACCEPT_TOKEN(aux_sym_resource_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(70);
+          lookahead != '"') ADVANCE(74);
       END_STATE();
-    case 54:
+    case 58:
       ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
-    case 55:
+    case 59:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 56:
+    case 60:
       ACCEPT_TOKEN(sym_component);
-      if (lookahead == '-') ADVANCE(57);
+      if (lookahead == '-') ADVANCE(61);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
       END_STATE();
-    case 57:
+    case 61:
       ACCEPT_TOKEN(sym_component);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(57);
-      END_STATE();
-    case 58:
-      ACCEPT_TOKEN(sym_any_component);
-      END_STATE();
-    case 59:
-      ACCEPT_TOKEN(sym_escape_sequence);
-      END_STATE();
-    case 60:
-      ACCEPT_TOKEN(aux_sym_resource_value_token1);
-      END_STATE();
-    case 61:
-      ACCEPT_TOKEN(aux_sym_resource_value_token1);
-      if (lookahead == '*') ADVANCE(6);
-      if (lookahead == '/') ADVANCE(45);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(61);
       END_STATE();
     case 62:
+      ACCEPT_TOKEN(sym_any_component);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(sym_escape_sequence);
+      END_STATE();
+    case 64:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
-      if (lookahead == 'd') ADVANCE(14);
-      if (lookahead == 'e') ADVANCE(27);
-      if (lookahead == 'i') ADVANCE(20);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(aux_sym_resource_value_token1);
+      if (lookahead == '*') ADVANCE(6);
+      if (lookahead == '/') ADVANCE(49);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(aux_sym_resource_value_token1);
+      if (lookahead == 'd') ADVANCE(15);
+      if (lookahead == 'e') ADVANCE(30);
+      if (lookahead == 'i') ADVANCE(22);
+      if (lookahead == 'u') ADVANCE(32);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(9);
       END_STATE();
-    case 63:
+    case 67:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == ' ' ||
           lookahead == '\\' ||
-          lookahead == 'n') ADVANCE(59);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(33);
-      END_STATE();
-    case 64:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '\r') ADVANCE(49);
-      if (lookahead == '\\') ADVANCE(43);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(45);
-      if (lookahead != 0) ADVANCE(44);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(68);
-      if (lookahead == '/') ADVANCE(44);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(70);
-      END_STATE();
-    case 67:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(67);
-      if (lookahead == '/') ADVANCE(50);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(6);
-      if (lookahead != 0) ADVANCE(68);
+          lookahead == 'n') ADVANCE(63);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(37);
       END_STATE();
     case 68:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(67);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(6);
-      if (lookahead != 0) ADVANCE(68);
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '/') ADVANCE(66);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(53);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(70);
+      if (lookahead == '\r') ADVANCE(53);
+      if (lookahead == '\\') ADVANCE(47);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(49);
+      if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '*') ADVANCE(72);
+      if (lookahead == '/') ADVANCE(48);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(70);
+          lookahead != '"') ADVANCE(74);
       END_STATE();
     case 71:
-      ACCEPT_TOKEN(aux_sym_include_directive_token1);
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '*') ADVANCE(71);
+      if (lookahead == '/') ADVANCE(54);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(6);
+      if (lookahead != 0) ADVANCE(72);
       END_STATE();
     case 72:
-      ACCEPT_TOKEN(aux_sym_define_directive_token1);
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '*') ADVANCE(71);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(6);
+      if (lookahead != 0) ADVANCE(72);
       END_STATE();
     case 73:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(6);
-      if (lookahead == '*') ADVANCE(73);
-      if (lookahead == '/') ADVANCE(47);
-      if (lookahead == '\\') ADVANCE(77);
-      if (lookahead != 0) ADVANCE(74);
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '/') ADVANCE(70);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(57);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(74);
       END_STATE();
     case 74:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\n') ADVANCE(6);
-      if (lookahead == '*') ADVANCE(73);
-      if (lookahead == '\\') ADVANCE(77);
-      if (lookahead != 0) ADVANCE(74);
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(74);
       END_STATE();
     case 75:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\r') ADVANCE(40);
-      if (lookahead == '\\') ADVANCE(42);
-      if (lookahead != 0) ADVANCE(48);
+      ACCEPT_TOKEN(aux_sym_include_directive_token1);
       END_STATE();
     case 76:
-      ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(74);
-      if (lookahead == '/') ADVANCE(48);
-      if (lookahead == '\\') ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(78);
+      ACCEPT_TOKEN(aux_sym_define_directive_token1);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '*') ADVANCE(73);
-      if (lookahead == '\\') ADVANCE(77);
-      if (lookahead != 0) ADVANCE(74);
+      if (lookahead == '\n') ADVANCE(6);
+      if (lookahead == '*') ADVANCE(77);
+      if (lookahead == '/') ADVANCE(51);
+      if (lookahead == '\\') ADVANCE(81);
+      if (lookahead != 0) ADVANCE(78);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\\') ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(78);
+      if (lookahead == '\n') ADVANCE(6);
+      if (lookahead == '*') ADVANCE(77);
+      if (lookahead == '\\') ADVANCE(81);
+      if (lookahead != 0) ADVANCE(78);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(sym_expansion);
-      if (lookahead == '\\') ADVANCE(79);
-      if (lookahead != 0) ADVANCE(78);
+      if (lookahead == '\r') ADVANCE(44);
+      if (lookahead == '\\') ADVANCE(46);
+      if (lookahead != 0) ADVANCE(52);
       END_STATE();
     case 80:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '*') ADVANCE(78);
+      if (lookahead == '/') ADVANCE(52);
+      if (lookahead == '\\') ADVANCE(83);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(82);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '*') ADVANCE(77);
+      if (lookahead == '\\') ADVANCE(81);
+      if (lookahead != 0) ADVANCE(78);
       END_STATE();
     case 82:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token3);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\\') ADVANCE(83);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(82);
       END_STATE();
     case 83:
-      ACCEPT_TOKEN(aux_sym_else_directive_token1);
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\\') ADVANCE(83);
+      if (lookahead != 0) ADVANCE(82);
       END_STATE();
     case 84:
+      ACCEPT_TOKEN(aux_sym_undef_directive_token1);
+      END_STATE();
+    case 85:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
+      END_STATE();
+    case 86:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
+      END_STATE();
+    case 87:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token3);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(aux_sym_else_directive_token1);
+      END_STATE();
+    case 89:
       ACCEPT_TOKEN(sym_identifier);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
     default:
       return false;
@@ -895,56 +928,58 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 35},
-  [2] = {.lex_state = 35},
-  [3] = {.lex_state = 35},
-  [4] = {.lex_state = 35},
-  [5] = {.lex_state = 35},
-  [6] = {.lex_state = 35},
-  [7] = {.lex_state = 35},
-  [8] = {.lex_state = 35},
-  [9] = {.lex_state = 35},
-  [10] = {.lex_state = 35},
-  [11] = {.lex_state = 35},
-  [12] = {.lex_state = 35},
-  [13] = {.lex_state = 1},
-  [14] = {.lex_state = 35},
-  [15] = {.lex_state = 35},
-  [16] = {.lex_state = 1},
-  [17] = {.lex_state = 35},
-  [18] = {.lex_state = 35},
-  [19] = {.lex_state = 35},
-  [20] = {.lex_state = 1},
-  [21] = {.lex_state = 1},
-  [22] = {.lex_state = 35},
-  [23] = {.lex_state = 35},
+  [1] = {.lex_state = 39},
+  [2] = {.lex_state = 39},
+  [3] = {.lex_state = 39},
+  [4] = {.lex_state = 39},
+  [5] = {.lex_state = 39},
+  [6] = {.lex_state = 39},
+  [7] = {.lex_state = 39},
+  [8] = {.lex_state = 39},
+  [9] = {.lex_state = 39},
+  [10] = {.lex_state = 39},
+  [11] = {.lex_state = 39},
+  [12] = {.lex_state = 39},
+  [13] = {.lex_state = 39},
+  [14] = {.lex_state = 1},
+  [15] = {.lex_state = 1},
+  [16] = {.lex_state = 39},
+  [17] = {.lex_state = 39},
+  [18] = {.lex_state = 1},
+  [19] = {.lex_state = 1},
+  [20] = {.lex_state = 39},
+  [21] = {.lex_state = 39},
+  [22] = {.lex_state = 39},
+  [23] = {.lex_state = 39},
   [24] = {.lex_state = 2},
-  [25] = {.lex_state = 35},
+  [25] = {.lex_state = 39},
   [26] = {.lex_state = 2},
   [27] = {.lex_state = 2},
   [28] = {.lex_state = 1},
-  [29] = {.lex_state = 35},
-  [30] = {.lex_state = 35},
+  [29] = {.lex_state = 39},
+  [30] = {.lex_state = 39},
   [31] = {.lex_state = 0},
   [32] = {.lex_state = 0},
-  [33] = {.lex_state = 7},
+  [33] = {.lex_state = 39},
   [34] = {.lex_state = 0},
   [35] = {.lex_state = 0},
-  [36] = {.lex_state = 0},
-  [37] = {.lex_state = 69},
-  [38] = {.lex_state = 0},
+  [36] = {.lex_state = 7},
+  [37] = {.lex_state = 0},
+  [38] = {.lex_state = 7},
   [39] = {.lex_state = 0},
-  [40] = {.lex_state = 35},
+  [40] = {.lex_state = 0},
   [41] = {.lex_state = 0},
   [42] = {.lex_state = 0},
-  [43] = {.lex_state = 7},
-  [44] = {.lex_state = 0},
-  [45] = {.lex_state = 0},
+  [43] = {.lex_state = 0},
+  [44] = {.lex_state = 39},
+  [45] = {.lex_state = 7},
   [46] = {.lex_state = 0},
-  [47] = {.lex_state = 35},
-  [48] = {.lex_state = 35},
+  [47] = {.lex_state = 73},
+  [48] = {.lex_state = 0},
   [49] = {.lex_state = 0},
   [50] = {.lex_state = 0},
+  [51] = {.lex_state = 39},
+  [52] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -964,6 +999,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_DQUOTE] = ACTIONS(1),
     [aux_sym_include_directive_token1] = ACTIONS(1),
     [aux_sym_define_directive_token1] = ACTIONS(1),
+    [aux_sym_undef_directive_token1] = ACTIONS(1),
     [aux_sym_ifdef_directive_token1] = ACTIONS(1),
     [aux_sym_ifdef_directive_token2] = ACTIONS(1),
     [aux_sym_ifdef_directive_token3] = ACTIONS(1),
@@ -971,18 +1007,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_identifier] = ACTIONS(1),
   },
   [1] = {
-    [sym_resources] = STATE(50),
-    [sym__line] = STATE(9),
-    [sym__statement] = STATE(44),
-    [sym_resource] = STATE(44),
-    [sym_components] = STATE(48),
+    [sym_resources] = STATE(39),
+    [sym__line] = STATE(8),
+    [sym__statement] = STATE(32),
+    [sym_resource] = STATE(32),
+    [sym_components] = STATE(30),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(44),
-    [sym_define_directive] = STATE(44),
-    [sym_ifdef_directive] = STATE(44),
+    [sym_include_directive] = STATE(32),
+    [sym_define_directive] = STATE(32),
+    [sym_undef_directive] = STATE(32),
+    [sym_ifdef_directive] = STATE(32),
     [aux_sym_resources_repeat1] = STATE(5),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(22),
+    [aux_sym_components_repeat2] = STATE(25),
     [ts_builtin_sym_end] = ACTIONS(5),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
@@ -994,50 +1031,54 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_any_component] = ACTIONS(15),
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
   },
   [2] = {
-    [sym__line] = STATE(9),
-    [sym__statement] = STATE(44),
-    [sym_resource] = STATE(44),
-    [sym_components] = STATE(48),
+    [sym__line] = STATE(8),
+    [sym__statement] = STATE(32),
+    [sym_resource] = STATE(32),
+    [sym_components] = STATE(30),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(44),
-    [sym_define_directive] = STATE(44),
-    [sym_ifdef_directive] = STATE(44),
+    [sym_include_directive] = STATE(32),
+    [sym_define_directive] = STATE(32),
+    [sym_undef_directive] = STATE(32),
+    [sym_ifdef_directive] = STATE(32),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(22),
-    [ts_builtin_sym_end] = ACTIONS(23),
-    [aux_sym__line_token1] = ACTIONS(25),
-    [sym_comment] = ACTIONS(28),
+    [aux_sym_components_repeat2] = STATE(25),
+    [ts_builtin_sym_end] = ACTIONS(25),
+    [aux_sym__line_token1] = ACTIONS(27),
+    [sym_comment] = ACTIONS(30),
     [sym_preprocessor_comment] = ACTIONS(3),
     [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(31),
-    [anon_sym_STAR] = ACTIONS(31),
-    [sym_component] = ACTIONS(34),
-    [sym_any_component] = ACTIONS(37),
-    [aux_sym_include_directive_token1] = ACTIONS(40),
-    [aux_sym_define_directive_token1] = ACTIONS(43),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(46),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(46),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(23),
-    [aux_sym_else_directive_token1] = ACTIONS(23),
+    [anon_sym_DOT] = ACTIONS(33),
+    [anon_sym_STAR] = ACTIONS(33),
+    [sym_component] = ACTIONS(36),
+    [sym_any_component] = ACTIONS(39),
+    [aux_sym_include_directive_token1] = ACTIONS(42),
+    [aux_sym_define_directive_token1] = ACTIONS(45),
+    [aux_sym_undef_directive_token1] = ACTIONS(48),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(51),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(51),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(25),
+    [aux_sym_else_directive_token1] = ACTIONS(25),
   },
   [3] = {
-    [sym__line] = STATE(9),
-    [sym__statement] = STATE(44),
-    [sym_resource] = STATE(44),
-    [sym_components] = STATE(48),
+    [sym__line] = STATE(8),
+    [sym__statement] = STATE(32),
+    [sym_resource] = STATE(32),
+    [sym_components] = STATE(30),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(44),
-    [sym_define_directive] = STATE(44),
-    [sym_ifdef_directive] = STATE(44),
-    [sym_else_directive] = STATE(47),
+    [sym_include_directive] = STATE(32),
+    [sym_define_directive] = STATE(32),
+    [sym_undef_directive] = STATE(32),
+    [sym_ifdef_directive] = STATE(32),
+    [sym_else_directive] = STATE(51),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(22),
+    [aux_sym_components_repeat2] = STATE(25),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1048,24 +1089,26 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_any_component] = ACTIONS(15),
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(49),
-    [aux_sym_else_directive_token1] = ACTIONS(51),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(54),
+    [aux_sym_else_directive_token1] = ACTIONS(56),
   },
   [4] = {
-    [sym__line] = STATE(9),
-    [sym__statement] = STATE(44),
-    [sym_resource] = STATE(44),
-    [sym_components] = STATE(48),
+    [sym__line] = STATE(8),
+    [sym__statement] = STATE(32),
+    [sym_resource] = STATE(32),
+    [sym_components] = STATE(30),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(44),
-    [sym_define_directive] = STATE(44),
-    [sym_ifdef_directive] = STATE(44),
-    [sym_else_directive] = STATE(30),
+    [sym_include_directive] = STATE(32),
+    [sym_define_directive] = STATE(32),
+    [sym_undef_directive] = STATE(32),
+    [sym_ifdef_directive] = STATE(32),
+    [sym_else_directive] = STATE(44),
     [aux_sym_resources_repeat1] = STATE(3),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(22),
+    [aux_sym_components_repeat2] = STATE(25),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1076,24 +1119,26 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_any_component] = ACTIONS(15),
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(53),
-    [aux_sym_else_directive_token1] = ACTIONS(51),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(58),
+    [aux_sym_else_directive_token1] = ACTIONS(56),
   },
   [5] = {
-    [sym__line] = STATE(9),
-    [sym__statement] = STATE(44),
-    [sym_resource] = STATE(44),
-    [sym_components] = STATE(48),
+    [sym__line] = STATE(8),
+    [sym__statement] = STATE(32),
+    [sym_resource] = STATE(32),
+    [sym_components] = STATE(30),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(44),
-    [sym_define_directive] = STATE(44),
-    [sym_ifdef_directive] = STATE(44),
+    [sym_include_directive] = STATE(32),
+    [sym_define_directive] = STATE(32),
+    [sym_undef_directive] = STATE(32),
+    [sym_ifdef_directive] = STATE(32),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(22),
-    [ts_builtin_sym_end] = ACTIONS(55),
+    [aux_sym_components_repeat2] = STATE(25),
+    [ts_builtin_sym_end] = ACTIONS(60),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1104,47 +1149,23 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_any_component] = ACTIONS(15),
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
   },
   [6] = {
-    [sym__line] = STATE(9),
-    [sym__statement] = STATE(44),
-    [sym_resource] = STATE(44),
-    [sym_components] = STATE(48),
+    [sym__line] = STATE(8),
+    [sym__statement] = STATE(32),
+    [sym_resource] = STATE(32),
+    [sym_components] = STATE(30),
     [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(44),
-    [sym_define_directive] = STATE(44),
-    [sym_ifdef_directive] = STATE(44),
-    [aux_sym_resources_repeat1] = STATE(7),
-    [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(22),
-    [aux_sym__line_token1] = ACTIONS(7),
-    [sym_comment] = ACTIONS(9),
-    [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_resource_token1] = ACTIONS(3),
-    [anon_sym_DOT] = ACTIONS(11),
-    [anon_sym_STAR] = ACTIONS(11),
-    [sym_component] = ACTIONS(13),
-    [sym_any_component] = ACTIONS(15),
-    [aux_sym_include_directive_token1] = ACTIONS(17),
-    [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(57),
-  },
-  [7] = {
-    [sym__line] = STATE(9),
-    [sym__statement] = STATE(44),
-    [sym_resource] = STATE(44),
-    [sym_components] = STATE(48),
-    [sym_binding] = STATE(10),
-    [sym_include_directive] = STATE(44),
-    [sym_define_directive] = STATE(44),
-    [sym_ifdef_directive] = STATE(44),
+    [sym_include_directive] = STATE(32),
+    [sym_define_directive] = STATE(32),
+    [sym_undef_directive] = STATE(32),
+    [sym_ifdef_directive] = STATE(32),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(22),
+    [aux_sym_components_repeat2] = STATE(25),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
@@ -1155,9 +1176,38 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_any_component] = ACTIONS(15),
     [aux_sym_include_directive_token1] = ACTIONS(17),
     [aux_sym_define_directive_token1] = ACTIONS(19),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(59),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(62),
+  },
+  [7] = {
+    [sym__line] = STATE(8),
+    [sym__statement] = STATE(32),
+    [sym_resource] = STATE(32),
+    [sym_components] = STATE(30),
+    [sym_binding] = STATE(10),
+    [sym_include_directive] = STATE(32),
+    [sym_define_directive] = STATE(32),
+    [sym_undef_directive] = STATE(32),
+    [sym_ifdef_directive] = STATE(32),
+    [aux_sym_resources_repeat1] = STATE(6),
+    [aux_sym_components_repeat1] = STATE(10),
+    [aux_sym_components_repeat2] = STATE(25),
+    [aux_sym__line_token1] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
+    [sym_preprocessor_comment] = ACTIONS(3),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_undef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(23),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(64),
   },
 };
 
@@ -1166,7 +1216,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(61), 13,
+    ACTIONS(66), 14,
       ts_builtin_sym_end,
       aux_sym__line_token1,
       sym_comment,
@@ -1176,15 +1226,16 @@ static const uint16_t ts_small_parse_table[] = {
       sym_any_component,
       aux_sym_include_directive_token1,
       aux_sym_define_directive_token1,
+      aux_sym_undef_directive_token1,
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
       aux_sym_ifdef_directive_token3,
       aux_sym_else_directive_token1,
-  [20] = 2,
+  [21] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(63), 13,
+    ACTIONS(68), 14,
       ts_builtin_sym_end,
       aux_sym__line_token1,
       sym_comment,
@@ -1194,16 +1245,17 @@ static const uint16_t ts_small_parse_table[] = {
       sym_any_component,
       aux_sym_include_directive_token1,
       aux_sym_define_directive_token1,
+      aux_sym_undef_directive_token1,
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
       aux_sym_ifdef_directive_token3,
       aux_sym_else_directive_token1,
-  [40] = 6,
+  [42] = 6,
     ACTIONS(15), 1,
       sym_any_component,
-    ACTIONS(65), 1,
+    ACTIONS(70), 1,
       sym_component,
-    STATE(25), 1,
+    STATE(22), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1214,49 +1266,34 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(11), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [62] = 4,
+  [64] = 4,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(67), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    ACTIONS(70), 2,
-      sym_component,
-      sym_any_component,
-    STATE(11), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [79] = 4,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
     ACTIONS(72), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    ACTIONS(75), 2,
       sym_component,
       sym_any_component,
     STATE(11), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [96] = 7,
-    ACTIONS(3), 1,
+  [81] = 4,
+    ACTIONS(3), 2,
       sym_preprocessor_comment,
-    ACTIONS(74), 1,
       aux_sym_resource_token1,
-    ACTIONS(76), 1,
-      sym_escape_sequence,
-    ACTIONS(78), 1,
-      aux_sym_resource_value_token1,
-    STATE(16), 1,
-      aux_sym_resource_repeat1,
-    STATE(20), 1,
-      aux_sym_resource_value_repeat1,
-    STATE(31), 1,
-      sym_resource_value,
-  [118] = 4,
-    ACTIONS(80), 1,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    ACTIONS(77), 2,
+      sym_component,
+      sym_any_component,
+    STATE(11), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [98] = 4,
+    ACTIONS(79), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1267,35 +1304,38 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(12), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [134] = 4,
-    ACTIONS(82), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-    ACTIONS(11), 2,
-      anon_sym_DOT,
-      anon_sym_STAR,
-    STATE(12), 2,
-      sym_binding,
-      aux_sym_components_repeat1,
-  [150] = 7,
+  [114] = 7,
     ACTIONS(3), 1,
       sym_preprocessor_comment,
-    ACTIONS(76), 1,
-      sym_escape_sequence,
-    ACTIONS(78), 1,
-      aux_sym_resource_value_token1,
-    ACTIONS(84), 1,
+    ACTIONS(81), 1,
       aux_sym_resource_token1,
-    STATE(20), 1,
+    ACTIONS(83), 1,
+      sym_escape_sequence,
+    ACTIONS(85), 1,
+      aux_sym_resource_value_token1,
+    STATE(19), 1,
       aux_sym_resource_value_repeat1,
     STATE(28), 1,
       aux_sym_resource_repeat1,
-    STATE(42), 1,
+    STATE(46), 1,
       sym_resource_value,
-  [172] = 4,
-    ACTIONS(86), 1,
+  [136] = 7,
+    ACTIONS(3), 1,
+      sym_preprocessor_comment,
+    ACTIONS(83), 1,
+      sym_escape_sequence,
+    ACTIONS(85), 1,
+      aux_sym_resource_value_token1,
+    ACTIONS(87), 1,
+      aux_sym_resource_token1,
+    STATE(14), 1,
+      aux_sym_resource_repeat1,
+    STATE(19), 1,
+      aux_sym_resource_value_repeat1,
+    STATE(37), 1,
+      sym_resource_value,
+  [158] = 4,
+    ACTIONS(89), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
@@ -1306,7 +1346,9 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(12), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [188] = 3,
+  [174] = 4,
+    ACTIONS(91), 1,
+      anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
@@ -1316,243 +1358,265 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(12), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [201] = 2,
+  [190] = 5,
+    ACTIONS(93), 1,
+      aux_sym__line_token1,
+    ACTIONS(95), 1,
+      sym_escape_sequence,
+    ACTIONS(98), 1,
+      aux_sym_resource_value_token1,
+    STATE(18), 1,
+      aux_sym_resource_value_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(88), 4,
+  [207] = 5,
+    ACTIONS(101), 1,
+      aux_sym__line_token1,
+    ACTIONS(103), 1,
+      sym_escape_sequence,
+    ACTIONS(105), 1,
+      aux_sym_resource_value_token1,
+    STATE(18), 1,
+      aux_sym_resource_value_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [224] = 2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+    ACTIONS(107), 4,
       anon_sym_DOT,
       anon_sym_STAR,
       sym_component,
       sym_any_component,
-  [212] = 5,
-    ACTIONS(90), 1,
-      aux_sym__line_token1,
-    ACTIONS(92), 1,
-      sym_escape_sequence,
-    ACTIONS(94), 1,
-      aux_sym_resource_value_token1,
-    STATE(21), 1,
-      aux_sym_resource_value_repeat1,
+  [235] = 3,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [229] = 5,
-    ACTIONS(96), 1,
-      aux_sym__line_token1,
-    ACTIONS(98), 1,
-      sym_escape_sequence,
-    ACTIONS(101), 1,
-      aux_sym_resource_value_token1,
-    STATE(21), 1,
-      aux_sym_resource_value_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [246] = 4,
+    ACTIONS(11), 2,
+      anon_sym_DOT,
+      anon_sym_STAR,
+    STATE(12), 2,
+      sym_binding,
+      aux_sym_components_repeat1,
+  [248] = 4,
     ACTIONS(15), 1,
       sym_any_component,
-    ACTIONS(65), 1,
+    ACTIONS(109), 1,
       sym_component,
     STATE(23), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [260] = 3,
+  [262] = 3,
     STATE(23), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-    ACTIONS(104), 2,
+    ACTIONS(111), 2,
       sym_component,
       sym_any_component,
-  [272] = 5,
-    ACTIONS(107), 1,
+  [274] = 5,
+    ACTIONS(114), 1,
       aux_sym__line_token1,
-    ACTIONS(109), 1,
+    ACTIONS(116), 1,
       sym_preprocessor_comment,
-    ACTIONS(111), 1,
+    ACTIONS(118), 1,
       aux_sym_resource_token1,
-    ACTIONS(113), 1,
+    ACTIONS(120), 1,
       sym_expansion,
     STATE(26), 1,
       aux_sym_resource_repeat1,
-  [288] = 4,
+  [290] = 4,
     ACTIONS(15), 1,
       sym_any_component,
-    ACTIONS(115), 1,
+    ACTIONS(70), 1,
       sym_component,
     STATE(23), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [302] = 5,
-    ACTIONS(109), 1,
+  [304] = 5,
+    ACTIONS(116), 1,
       sym_preprocessor_comment,
-    ACTIONS(117), 1,
+    ACTIONS(122), 1,
       aux_sym__line_token1,
-    ACTIONS(119), 1,
+    ACTIONS(124), 1,
       aux_sym_resource_token1,
-    ACTIONS(121), 1,
+    ACTIONS(127), 1,
       sym_expansion,
-    STATE(27), 1,
+    STATE(26), 1,
       aux_sym_resource_repeat1,
-  [318] = 5,
-    ACTIONS(109), 1,
+  [320] = 5,
+    ACTIONS(116), 1,
       sym_preprocessor_comment,
-    ACTIONS(123), 1,
+    ACTIONS(129), 1,
       aux_sym__line_token1,
-    ACTIONS(125), 1,
+    ACTIONS(131), 1,
       aux_sym_resource_token1,
-    ACTIONS(128), 1,
+    ACTIONS(133), 1,
       sym_expansion,
-    STATE(27), 1,
+    STATE(24), 1,
       aux_sym_resource_repeat1,
-  [334] = 5,
+  [336] = 5,
     ACTIONS(3), 1,
       sym_preprocessor_comment,
-    ACTIONS(123), 1,
+    ACTIONS(122), 1,
       sym_escape_sequence,
-    ACTIONS(128), 1,
+    ACTIONS(127), 1,
       aux_sym_resource_value_token1,
-    ACTIONS(130), 1,
+    ACTIONS(135), 1,
       aux_sym_resource_token1,
     STATE(28), 1,
       aux_sym_resource_repeat1,
-  [350] = 3,
-    ACTIONS(133), 1,
+  [352] = 3,
+    ACTIONS(138), 1,
       anon_sym_DQUOTE,
-    STATE(34), 1,
+    STATE(48), 1,
       sym_string,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [361] = 2,
-    ACTIONS(135), 1,
-      aux_sym_ifdef_directive_token3,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [369] = 2,
-    ACTIONS(137), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [377] = 2,
-    ACTIONS(139), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [385] = 2,
-    ACTIONS(141), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [393] = 2,
-    ACTIONS(143), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [401] = 2,
-    ACTIONS(145), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [409] = 2,
-    ACTIONS(147), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [417] = 2,
-    ACTIONS(149), 1,
-      aux_sym_string_token1,
-    ACTIONS(109), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [425] = 2,
-    ACTIONS(151), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [433] = 2,
-    ACTIONS(153), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [441] = 2,
-    ACTIONS(155), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [449] = 2,
-    ACTIONS(157), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [457] = 2,
-    ACTIONS(159), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [465] = 2,
-    ACTIONS(161), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [473] = 2,
-    ACTIONS(163), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [481] = 2,
-    ACTIONS(165), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [489] = 2,
-    ACTIONS(167), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [497] = 2,
-    ACTIONS(169), 1,
-      aux_sym_ifdef_directive_token3,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_resource_token1,
-  [505] = 2,
-    ACTIONS(171), 1,
+  [363] = 2,
+    ACTIONS(140), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [513] = 2,
-    ACTIONS(173), 1,
+  [371] = 2,
+    ACTIONS(142), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
-  [521] = 2,
-    ACTIONS(175), 1,
+  [379] = 2,
+    ACTIONS(144), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [387] = 2,
+    ACTIONS(146), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [395] = 2,
+    ACTIONS(148), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [403] = 2,
+    ACTIONS(150), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [411] = 2,
+    ACTIONS(152), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [419] = 2,
+    ACTIONS(154), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [427] = 2,
+    ACTIONS(156), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [435] = 2,
+    ACTIONS(158), 1,
       ts_builtin_sym_end,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [443] = 2,
+    ACTIONS(160), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [451] = 2,
+    ACTIONS(162), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [459] = 2,
+    ACTIONS(164), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [467] = 2,
+    ACTIONS(166), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [475] = 2,
+    ACTIONS(168), 1,
+      aux_sym_ifdef_directive_token3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [483] = 2,
+    ACTIONS(170), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [491] = 2,
+    ACTIONS(172), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [499] = 2,
+    ACTIONS(174), 1,
+      aux_sym_string_token1,
+    ACTIONS(116), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [507] = 2,
+    ACTIONS(176), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [515] = 2,
+    ACTIONS(178), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [523] = 2,
+    ACTIONS(180), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [531] = 2,
+    ACTIONS(182), 1,
+      aux_sym_ifdef_directive_token3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [539] = 2,
+    ACTIONS(184), 1,
+      aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
       aux_sym_resource_token1,
@@ -1560,48 +1624,50 @@ static const uint16_t ts_small_parse_table[] = {
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(8)] = 0,
-  [SMALL_STATE(9)] = 20,
-  [SMALL_STATE(10)] = 40,
-  [SMALL_STATE(11)] = 62,
-  [SMALL_STATE(12)] = 79,
-  [SMALL_STATE(13)] = 96,
-  [SMALL_STATE(14)] = 118,
-  [SMALL_STATE(15)] = 134,
-  [SMALL_STATE(16)] = 150,
-  [SMALL_STATE(17)] = 172,
-  [SMALL_STATE(18)] = 188,
-  [SMALL_STATE(19)] = 201,
-  [SMALL_STATE(20)] = 212,
-  [SMALL_STATE(21)] = 229,
-  [SMALL_STATE(22)] = 246,
-  [SMALL_STATE(23)] = 260,
-  [SMALL_STATE(24)] = 272,
-  [SMALL_STATE(25)] = 288,
-  [SMALL_STATE(26)] = 302,
-  [SMALL_STATE(27)] = 318,
-  [SMALL_STATE(28)] = 334,
-  [SMALL_STATE(29)] = 350,
-  [SMALL_STATE(30)] = 361,
-  [SMALL_STATE(31)] = 369,
-  [SMALL_STATE(32)] = 377,
-  [SMALL_STATE(33)] = 385,
-  [SMALL_STATE(34)] = 393,
-  [SMALL_STATE(35)] = 401,
-  [SMALL_STATE(36)] = 409,
-  [SMALL_STATE(37)] = 417,
-  [SMALL_STATE(38)] = 425,
-  [SMALL_STATE(39)] = 433,
-  [SMALL_STATE(40)] = 441,
-  [SMALL_STATE(41)] = 449,
-  [SMALL_STATE(42)] = 457,
-  [SMALL_STATE(43)] = 465,
-  [SMALL_STATE(44)] = 473,
-  [SMALL_STATE(45)] = 481,
-  [SMALL_STATE(46)] = 489,
-  [SMALL_STATE(47)] = 497,
-  [SMALL_STATE(48)] = 505,
-  [SMALL_STATE(49)] = 513,
-  [SMALL_STATE(50)] = 521,
+  [SMALL_STATE(9)] = 21,
+  [SMALL_STATE(10)] = 42,
+  [SMALL_STATE(11)] = 64,
+  [SMALL_STATE(12)] = 81,
+  [SMALL_STATE(13)] = 98,
+  [SMALL_STATE(14)] = 114,
+  [SMALL_STATE(15)] = 136,
+  [SMALL_STATE(16)] = 158,
+  [SMALL_STATE(17)] = 174,
+  [SMALL_STATE(18)] = 190,
+  [SMALL_STATE(19)] = 207,
+  [SMALL_STATE(20)] = 224,
+  [SMALL_STATE(21)] = 235,
+  [SMALL_STATE(22)] = 248,
+  [SMALL_STATE(23)] = 262,
+  [SMALL_STATE(24)] = 274,
+  [SMALL_STATE(25)] = 290,
+  [SMALL_STATE(26)] = 304,
+  [SMALL_STATE(27)] = 320,
+  [SMALL_STATE(28)] = 336,
+  [SMALL_STATE(29)] = 352,
+  [SMALL_STATE(30)] = 363,
+  [SMALL_STATE(31)] = 371,
+  [SMALL_STATE(32)] = 379,
+  [SMALL_STATE(33)] = 387,
+  [SMALL_STATE(34)] = 395,
+  [SMALL_STATE(35)] = 403,
+  [SMALL_STATE(36)] = 411,
+  [SMALL_STATE(37)] = 419,
+  [SMALL_STATE(38)] = 427,
+  [SMALL_STATE(39)] = 435,
+  [SMALL_STATE(40)] = 443,
+  [SMALL_STATE(41)] = 451,
+  [SMALL_STATE(42)] = 459,
+  [SMALL_STATE(43)] = 467,
+  [SMALL_STATE(44)] = 475,
+  [SMALL_STATE(45)] = 483,
+  [SMALL_STATE(46)] = 491,
+  [SMALL_STATE(47)] = 499,
+  [SMALL_STATE(48)] = 507,
+  [SMALL_STATE(49)] = 515,
+  [SMALL_STATE(50)] = 523,
+  [SMALL_STATE(51)] = 531,
+  [SMALL_STATE(52)] = 539,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -1609,84 +1675,88 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 0, 0, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
   [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
   [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
-  [25] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(9),
-  [28] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(44),
-  [31] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
-  [34] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
-  [37] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
-  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(29),
-  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(43),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
-  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
-  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
-  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
-  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [67] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
-  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
-  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
-  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [78] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
-  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
-  [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
-  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
-  [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
-  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [94] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
-  [98] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
-  [101] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
-  [104] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(18),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
-  [109] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [111] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [113] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 2),
-  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [121] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [125] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
-  [128] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
-  [130] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
-  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 4),
-  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
-  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
-  [147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 4, 0, 5),
-  [149] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 6),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
-  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 7),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 8),
-  [167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 9),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 10),
-  [175] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
+  [27] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(8),
+  [30] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
+  [33] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(20),
+  [36] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
+  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
+  [42] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(29),
+  [45] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(36),
+  [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(38),
+  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(45),
+  [54] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [56] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [60] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
+  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
+  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
+  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
+  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
+  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [72] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(20),
+  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
+  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
+  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
+  [81] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [83] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [85] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [87] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
+  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
+  [95] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
+  [98] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
+  [101] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
+  [103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [105] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
+  [109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [111] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(21),
+  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 2),
+  [116] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [124] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(26),
+  [127] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
+  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [133] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [135] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
+  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_undef_directive, 2, 0, 2),
+  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
+  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 4),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [158] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [160] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
+  [162] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 4, 0, 5),
+  [164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 6),
+  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 7),
+  [174] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
+  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
+  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 8),
+  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 9),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 10),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,11 +5,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 54
+#define STATE_COUNT 51
 #define LARGE_STATE_COUNT 8
-#define SYMBOL_COUNT 43
+#define SYMBOL_COUNT 39
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 24
+#define TOKEN_COUNT 22
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 6
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
@@ -19,46 +19,42 @@ enum ts_symbol_identifiers {
   aux_sym__line_token1 = 1,
   sym_comment = 2,
   sym_preprocessor_comment = 3,
-  aux_sym_include_directive_token1 = 4,
-  aux_sym_define_directive_token1 = 5,
-  aux_sym_define_directive_token2 = 6,
-  aux_sym_expansion_token1 = 7,
-  aux_sym_expansion_token2 = 8,
-  aux_sym_expansion_token3 = 9,
-  aux_sym_ifdef_directive_token1 = 10,
-  aux_sym_ifdef_directive_token2 = 11,
-  aux_sym_ifdef_directive_token3 = 12,
-  aux_sym_else_directive_token1 = 13,
-  sym_identifier = 14,
-  anon_sym_COLON = 15,
-  anon_sym_DOT = 16,
-  anon_sym_STAR = 17,
-  sym_component = 18,
-  sym_any_component = 19,
-  sym_escape_sequence = 20,
-  aux_sym_resource_value_token1 = 21,
-  anon_sym_DQUOTE = 22,
-  aux_sym_string_token1 = 23,
-  sym_resources = 24,
-  sym__line = 25,
-  sym__statement = 26,
-  sym_include_directive = 27,
-  sym_define_directive = 28,
-  sym_expansion = 29,
-  sym_ifdef_directive = 30,
-  sym_else_directive = 31,
-  sym_resource = 32,
-  sym_components = 33,
-  sym_binding = 34,
-  sym_resource_value = 35,
-  sym_string = 36,
-  aux_sym_resources_repeat1 = 37,
-  aux_sym_define_directive_repeat1 = 38,
-  aux_sym_expansion_repeat1 = 39,
-  aux_sym_components_repeat1 = 40,
-  aux_sym_components_repeat2 = 41,
-  aux_sym_resource_value_repeat1 = 42,
-  alias_sym_body = 43,
+  anon_sym_COLON = 4,
+  aux_sym_resource_token1 = 5,
+  anon_sym_DOT = 6,
+  anon_sym_STAR = 7,
+  sym_component = 8,
+  sym_any_component = 9,
+  sym_escape_sequence = 10,
+  aux_sym_resource_value_token1 = 11,
+  anon_sym_DQUOTE = 12,
+  aux_sym_string_token1 = 13,
+  aux_sym_include_directive_token1 = 14,
+  aux_sym_define_directive_token1 = 15,
+  sym_expansion = 16,
+  aux_sym_ifdef_directive_token1 = 17,
+  aux_sym_ifdef_directive_token2 = 18,
+  aux_sym_ifdef_directive_token3 = 19,
+  aux_sym_else_directive_token1 = 20,
+  sym_identifier = 21,
+  sym_resources = 22,
+  sym__line = 23,
+  sym__statement = 24,
+  sym_resource = 25,
+  sym_components = 26,
+  sym_binding = 27,
+  sym_resource_value = 28,
+  sym_string = 29,
+  sym_include_directive = 30,
+  sym_define_directive = 31,
+  sym_ifdef_directive = 32,
+  sym_else_directive = 33,
+  aux_sym_resources_repeat1 = 34,
+  aux_sym_resource_repeat1 = 35,
+  aux_sym_components_repeat1 = 36,
+  aux_sym_components_repeat2 = 37,
+  aux_sym_resource_value_repeat1 = 38,
+  alias_sym_body = 39,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -66,18 +62,8 @@ static const char * const ts_symbol_names[] = {
   [aux_sym__line_token1] = "_line_token1",
   [sym_comment] = "comment",
   [sym_preprocessor_comment] = "preprocessor_comment",
-  [aux_sym_include_directive_token1] = "#include",
-  [aux_sym_define_directive_token1] = "#define",
-  [aux_sym_define_directive_token2] = "define_directive_token2",
-  [aux_sym_expansion_token1] = "expansion_token1",
-  [aux_sym_expansion_token2] = "expansion_token2",
-  [aux_sym_expansion_token3] = "expansion_token3",
-  [aux_sym_ifdef_directive_token1] = "#ifdef",
-  [aux_sym_ifdef_directive_token2] = "#ifndef",
-  [aux_sym_ifdef_directive_token3] = "#endif",
-  [aux_sym_else_directive_token1] = "#else",
-  [sym_identifier] = "identifier",
   [anon_sym_COLON] = ":",
+  [aux_sym_resource_token1] = "resource_token1",
   [anon_sym_DOT] = ".",
   [anon_sym_STAR] = "*",
   [sym_component] = "component",
@@ -86,22 +72,28 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_resource_value_token1] = "resource_value_token1",
   [anon_sym_DQUOTE] = "\"",
   [aux_sym_string_token1] = "string_content",
+  [aux_sym_include_directive_token1] = "#include",
+  [aux_sym_define_directive_token1] = "#define",
+  [sym_expansion] = "expansion",
+  [aux_sym_ifdef_directive_token1] = "#ifdef",
+  [aux_sym_ifdef_directive_token2] = "#ifndef",
+  [aux_sym_ifdef_directive_token3] = "#endif",
+  [aux_sym_else_directive_token1] = "#else",
+  [sym_identifier] = "identifier",
   [sym_resources] = "resources",
   [sym__line] = "_line",
   [sym__statement] = "_statement",
-  [sym_include_directive] = "include_directive",
-  [sym_define_directive] = "define_directive",
-  [sym_expansion] = "expansion",
-  [sym_ifdef_directive] = "ifdef_directive",
-  [sym_else_directive] = "else_directive",
   [sym_resource] = "resource",
   [sym_components] = "components",
   [sym_binding] = "binding",
   [sym_resource_value] = "resource_value",
   [sym_string] = "string",
+  [sym_include_directive] = "include_directive",
+  [sym_define_directive] = "define_directive",
+  [sym_ifdef_directive] = "ifdef_directive",
+  [sym_else_directive] = "else_directive",
   [aux_sym_resources_repeat1] = "resources_repeat1",
-  [aux_sym_define_directive_repeat1] = "define_directive_repeat1",
-  [aux_sym_expansion_repeat1] = "expansion_repeat1",
+  [aux_sym_resource_repeat1] = "resource_repeat1",
   [aux_sym_components_repeat1] = "components_repeat1",
   [aux_sym_components_repeat2] = "components_repeat2",
   [aux_sym_resource_value_repeat1] = "resource_value_repeat1",
@@ -113,18 +105,8 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym__line_token1] = aux_sym__line_token1,
   [sym_comment] = sym_comment,
   [sym_preprocessor_comment] = sym_preprocessor_comment,
-  [aux_sym_include_directive_token1] = aux_sym_include_directive_token1,
-  [aux_sym_define_directive_token1] = aux_sym_define_directive_token1,
-  [aux_sym_define_directive_token2] = aux_sym_define_directive_token2,
-  [aux_sym_expansion_token1] = aux_sym_expansion_token1,
-  [aux_sym_expansion_token2] = aux_sym_expansion_token2,
-  [aux_sym_expansion_token3] = aux_sym_expansion_token3,
-  [aux_sym_ifdef_directive_token1] = aux_sym_ifdef_directive_token1,
-  [aux_sym_ifdef_directive_token2] = aux_sym_ifdef_directive_token2,
-  [aux_sym_ifdef_directive_token3] = aux_sym_ifdef_directive_token3,
-  [aux_sym_else_directive_token1] = aux_sym_else_directive_token1,
-  [sym_identifier] = sym_identifier,
   [anon_sym_COLON] = anon_sym_COLON,
+  [aux_sym_resource_token1] = aux_sym_resource_token1,
   [anon_sym_DOT] = anon_sym_DOT,
   [anon_sym_STAR] = anon_sym_STAR,
   [sym_component] = sym_component,
@@ -133,22 +115,28 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_resource_value_token1] = aux_sym_resource_value_token1,
   [anon_sym_DQUOTE] = anon_sym_DQUOTE,
   [aux_sym_string_token1] = aux_sym_string_token1,
+  [aux_sym_include_directive_token1] = aux_sym_include_directive_token1,
+  [aux_sym_define_directive_token1] = aux_sym_define_directive_token1,
+  [sym_expansion] = sym_expansion,
+  [aux_sym_ifdef_directive_token1] = aux_sym_ifdef_directive_token1,
+  [aux_sym_ifdef_directive_token2] = aux_sym_ifdef_directive_token2,
+  [aux_sym_ifdef_directive_token3] = aux_sym_ifdef_directive_token3,
+  [aux_sym_else_directive_token1] = aux_sym_else_directive_token1,
+  [sym_identifier] = sym_identifier,
   [sym_resources] = sym_resources,
   [sym__line] = sym__line,
   [sym__statement] = sym__statement,
-  [sym_include_directive] = sym_include_directive,
-  [sym_define_directive] = sym_define_directive,
-  [sym_expansion] = sym_expansion,
-  [sym_ifdef_directive] = sym_ifdef_directive,
-  [sym_else_directive] = sym_else_directive,
   [sym_resource] = sym_resource,
   [sym_components] = sym_components,
   [sym_binding] = sym_binding,
   [sym_resource_value] = sym_resource_value,
   [sym_string] = sym_string,
+  [sym_include_directive] = sym_include_directive,
+  [sym_define_directive] = sym_define_directive,
+  [sym_ifdef_directive] = sym_ifdef_directive,
+  [sym_else_directive] = sym_else_directive,
   [aux_sym_resources_repeat1] = aux_sym_resources_repeat1,
-  [aux_sym_define_directive_repeat1] = aux_sym_define_directive_repeat1,
-  [aux_sym_expansion_repeat1] = aux_sym_expansion_repeat1,
+  [aux_sym_resource_repeat1] = aux_sym_resource_repeat1,
   [aux_sym_components_repeat1] = aux_sym_components_repeat1,
   [aux_sym_components_repeat2] = aux_sym_components_repeat2,
   [aux_sym_resource_value_repeat1] = aux_sym_resource_value_repeat1,
@@ -172,52 +160,12 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [aux_sym_include_directive_token1] = {
-    .visible = true,
-    .named = false,
-  },
-  [aux_sym_define_directive_token1] = {
-    .visible = true,
-    .named = false,
-  },
-  [aux_sym_define_directive_token2] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_expansion_token1] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_expansion_token2] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_expansion_token3] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_ifdef_directive_token1] = {
-    .visible = true,
-    .named = false,
-  },
-  [aux_sym_ifdef_directive_token2] = {
-    .visible = true,
-    .named = false,
-  },
-  [aux_sym_ifdef_directive_token3] = {
-    .visible = true,
-    .named = false,
-  },
-  [aux_sym_else_directive_token1] = {
-    .visible = true,
-    .named = false,
-  },
-  [sym_identifier] = {
-    .visible = true,
-    .named = true,
-  },
   [anon_sym_COLON] = {
     .visible = true,
+    .named = false,
+  },
+  [aux_sym_resource_token1] = {
+    .visible = false,
     .named = false,
   },
   [anon_sym_DOT] = {
@@ -252,6 +200,38 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [aux_sym_include_directive_token1] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_define_directive_token1] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_expansion] = {
+    .visible = true,
+    .named = true,
+  },
+  [aux_sym_ifdef_directive_token1] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_ifdef_directive_token2] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_ifdef_directive_token3] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_else_directive_token1] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_identifier] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_resources] = {
     .visible = true,
     .named = true,
@@ -262,26 +242,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [sym__statement] = {
     .visible = false,
-    .named = true,
-  },
-  [sym_include_directive] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_define_directive] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_expansion] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_ifdef_directive] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_else_directive] = {
-    .visible = true,
     .named = true,
   },
   [sym_resource] = {
@@ -304,15 +264,27 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_include_directive] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_define_directive] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_ifdef_directive] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_else_directive] = {
+    .visible = true,
+    .named = true,
+  },
   [aux_sym_resources_repeat1] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_define_directive_repeat1] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_expansion_repeat1] = {
+  [aux_sym_resource_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -443,10 +415,10 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [25] = 25,
   [26] = 26,
   [27] = 27,
-  [28] = 28,
+  [28] = 27,
   [29] = 29,
   [30] = 30,
-  [31] = 28,
+  [31] = 31,
   [32] = 32,
   [33] = 33,
   [34] = 34,
@@ -466,9 +438,6 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [48] = 48,
   [49] = 49,
   [50] = 50,
-  [51] = 51,
-  [52] = 52,
-  [53] = 53,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -476,436 +445,448 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(37);
+      if (eof) ADVANCE(36);
       ADVANCE_MAP(
-        0, 52,
-        '\n', 38,
-        '!', 39,
-        '"', 77,
-        '#', 56,
-        '*', 70,
-        '.', 69,
-        '/', 54,
-        ':', 68,
-        '?', 72,
-        '\\', 53,
-        '\t', 50,
-        ' ', 50,
+        '\n', 37,
+        '!', 38,
+        '"', 64,
+        '#', 62,
+        '*', 55,
+        '.', 54,
+        '/', 61,
+        ':', 51,
+        '?', 58,
+        '\\', 63,
+        '\t', 52,
+        ' ', 52,
       );
-      if ((0x0b <= lookahead && lookahead <= '\r')) ADVANCE(58);
       if (('-' <= lookahead && lookahead <= '9')) ADVANCE(57);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
-      if (lookahead != 0) ADVANCE(52);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      if (lookahead != 0) ADVANCE(60);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(38);
-      if (lookahead == '/') ADVANCE(54);
+      if (lookahead == '\n') ADVANCE(37);
+      if (lookahead == '/') ADVANCE(61);
+      if (lookahead == '\\') ADVANCE(63);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(50);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(52);
+          lookahead == ' ') ADVANCE(52);
+      if (lookahead != 0) ADVANCE(60);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(38);
-      if (lookahead == '/') ADVANCE(75);
-      if (lookahead == '\\') ADVANCE(76);
+      if (lookahead == '\n') ADVANCE(37);
+      if (lookahead == '/') ADVANCE(76);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(50);
-      if (lookahead != 0) ADVANCE(74);
+          lookahead == ' ') ADVANCE(52);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(78);
       END_STATE();
     case 3:
-      if (lookahead == '\n') ADVANCE(38);
-      if (lookahead == '/') ADVANCE(60);
-      if (lookahead == '\\') ADVANCE(59);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(50);
-      if (lookahead != 0) ADVANCE(58);
+      if (lookahead == '\r') ADVANCE(46);
+      if (lookahead == '\\') ADVANCE(41);
+      if (lookahead != 0) ADVANCE(45);
       END_STATE();
     case 4:
-      if (lookahead == '\r') ADVANCE(45);
-      if (lookahead == '\\') ADVANCE(41);
-      if (lookahead != 0) ADVANCE(44);
+      if (lookahead == '*') ADVANCE(6);
+      if (lookahead == '/') ADVANCE(45);
       END_STATE();
     case 5:
-      if (lookahead == '*') ADVANCE(7);
-      if (lookahead == '/') ADVANCE(44);
+      if (lookahead == '*') ADVANCE(5);
+      if (lookahead == '/') ADVANCE(39);
+      if (lookahead != 0) ADVANCE(6);
       END_STATE();
     case 6:
-      if (lookahead == '*') ADVANCE(6);
-      if (lookahead == '/') ADVANCE(40);
-      if (lookahead != 0) ADVANCE(7);
+      if (lookahead == '*') ADVANCE(5);
+      if (lookahead != 0) ADVANCE(6);
       END_STATE();
     case 7:
-      if (lookahead == '*') ADVANCE(6);
-      if (lookahead != 0) ADVANCE(7);
-      END_STATE();
-    case 8:
-      if (lookahead == '/') ADVANCE(5);
+      if (lookahead == '/') ADVANCE(4);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(50);
+          lookahead == ' ') ADVANCE(52);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(35);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(34);
+      END_STATE();
+    case 8:
+      if (lookahead == 'c') ADVANCE(28);
       END_STATE();
     case 9:
-      if (lookahead == 'c') ADVANCE(29);
+      if (lookahead == 'd') ADVANCE(14);
+      if (lookahead == 'e') ADVANCE(27);
+      if (lookahead == 'i') ADVANCE(20);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(9);
       END_STATE();
     case 10:
-      if (lookahead == 'd') ADVANCE(15);
-      if (lookahead == 'e') ADVANCE(28);
-      if (lookahead == 'i') ADVANCE(21);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(10);
+      if (lookahead == 'd') ADVANCE(26);
       END_STATE();
     case 11:
-      if (lookahead == 'd') ADVANCE(27);
+      if (lookahead == 'd') ADVANCE(17);
       END_STATE();
     case 12:
       if (lookahead == 'd') ADVANCE(18);
+      if (lookahead == 'n') ADVANCE(13);
       END_STATE();
     case 13:
       if (lookahead == 'd') ADVANCE(19);
-      if (lookahead == 'n') ADVANCE(14);
       END_STATE();
     case 14:
-      if (lookahead == 'd') ADVANCE(20);
+      if (lookahead == 'e') ADVANCE(21);
       END_STATE();
     case 15:
-      if (lookahead == 'e') ADVANCE(22);
+      if (lookahead == 'e') ADVANCE(83);
       END_STATE();
     case 16:
-      if (lookahead == 'e') ADVANCE(65);
+      if (lookahead == 'e') ADVANCE(72);
       END_STATE();
     case 17:
-      if (lookahead == 'e') ADVANCE(49);
+      if (lookahead == 'e') ADVANCE(71);
       END_STATE();
     case 18:
-      if (lookahead == 'e') ADVANCE(48);
+      if (lookahead == 'e') ADVANCE(23);
       END_STATE();
     case 19:
       if (lookahead == 'e') ADVANCE(24);
       END_STATE();
     case 20:
-      if (lookahead == 'e') ADVANCE(25);
+      if (lookahead == 'f') ADVANCE(12);
+      if (lookahead == 'n') ADVANCE(8);
       END_STATE();
     case 21:
-      if (lookahead == 'f') ADVANCE(13);
-      if (lookahead == 'n') ADVANCE(9);
+      if (lookahead == 'f') ADVANCE(25);
       END_STATE();
     case 22:
-      if (lookahead == 'f') ADVANCE(26);
+      if (lookahead == 'f') ADVANCE(82);
       END_STATE();
     case 23:
-      if (lookahead == 'f') ADVANCE(64);
+      if (lookahead == 'f') ADVANCE(80);
       END_STATE();
     case 24:
-      if (lookahead == 'f') ADVANCE(62);
+      if (lookahead == 'f') ADVANCE(81);
       END_STATE();
     case 25:
-      if (lookahead == 'f') ADVANCE(63);
+      if (lookahead == 'i') ADVANCE(29);
       END_STATE();
     case 26:
-      if (lookahead == 'i') ADVANCE(30);
+      if (lookahead == 'i') ADVANCE(22);
       END_STATE();
     case 27:
-      if (lookahead == 'i') ADVANCE(23);
+      if (lookahead == 'l') ADVANCE(30);
+      if (lookahead == 'n') ADVANCE(10);
       END_STATE();
     case 28:
       if (lookahead == 'l') ADVANCE(31);
-      if (lookahead == 'n') ADVANCE(11);
       END_STATE();
     case 29:
-      if (lookahead == 'l') ADVANCE(32);
+      if (lookahead == 'n') ADVANCE(16);
       END_STATE();
     case 30:
-      if (lookahead == 'n') ADVANCE(17);
+      if (lookahead == 's') ADVANCE(15);
       END_STATE();
     case 31:
-      if (lookahead == 's') ADVANCE(16);
+      if (lookahead == 'u') ADVANCE(11);
       END_STATE();
     case 32:
-      if (lookahead == 'u') ADVANCE(12);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(59);
       END_STATE();
     case 33:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(32);
       END_STATE();
     case 34:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(33);
-      END_STATE();
-    case 35:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(67);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
       END_STATE();
-    case 36:
-      if (eof) ADVANCE(37);
+    case 35:
+      if (eof) ADVANCE(36);
       ADVANCE_MAP(
-        '\n', 38,
-        '!', 39,
-        '"', 77,
-        '#', 10,
-        '*', 70,
-        '.', 69,
-        '/', 5,
-        ':', 68,
-        '?', 72,
-        '\t', 50,
-        ' ', 50,
+        '\n', 37,
+        '!', 38,
+        '"', 64,
+        '#', 9,
+        '*', 55,
+        '.', 54,
+        '/', 4,
+        ':', 51,
+        '?', 58,
+        '\t', 52,
+        ' ', 52,
       );
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(71);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(57);
       END_STATE();
-    case 37:
+    case 36:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 38:
+    case 37:
       ACCEPT_TOKEN(aux_sym__line_token1);
       END_STATE();
-    case 39:
+    case 38:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(39);
+          lookahead != '\n') ADVANCE(38);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(sym_preprocessor_comment);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\n') ADVANCE(45);
+      if (lookahead == '\\') ADVANCE(75);
+      if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(45);
+      if (lookahead == '\r') ADVANCE(46);
       if (lookahead == '\\') ADVANCE(41);
-      if (lookahead != 0) ADVANCE(44);
+      if (lookahead != 0) ADVANCE(45);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\r') ADVANCE(46);
+      if (lookahead == '\r') ADVANCE(40);
       if (lookahead == '\\') ADVANCE(42);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(44);
-      if (lookahead != 0) ADVANCE(43);
+      if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '"') ADVANCE(44);
-      if (lookahead == '\\') ADVANCE(78);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(43);
+      if (lookahead == '\r') ADVANCE(49);
+      if (lookahead == '\\') ADVANCE(43);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(45);
+      if (lookahead != 0) ADVANCE(44);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(4);
+      if (lookahead == '"') ADVANCE(45);
+      if (lookahead == '\\') ADVANCE(65);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(44);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(4);
-      if (lookahead != 0) ADVANCE(44);
+      if (lookahead == '\\') ADVANCE(3);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(45);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(sym_preprocessor_comment);
-      if (lookahead == '\\') ADVANCE(78);
-      if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(44);
-      if (lookahead != 0) ADVANCE(43);
+      if (lookahead == '\\') ADVANCE(3);
+      if (lookahead != 0) ADVANCE(45);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(79);
       if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"') ADVANCE(83);
+          lookahead != '\n') ADVANCE(78);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(aux_sym_include_directive_token1);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(75);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(48);
       END_STATE();
     case 49:
-      ACCEPT_TOKEN(aux_sym_define_directive_token1);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
+      if (lookahead == '\\') ADVANCE(65);
+      if (lookahead == '\n' ||
+          lookahead == '"') ADVANCE(45);
+      if (lookahead != 0) ADVANCE(44);
       END_STATE();
     case 50:
-      ACCEPT_TOKEN(aux_sym_define_directive_token2);
-      END_STATE();
-    case 51:
-      ACCEPT_TOKEN(aux_sym_define_directive_token2);
+      ACCEPT_TOKEN(sym_preprocessor_comment);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(83);
+          lookahead != '"') ADVANCE(70);
       END_STATE();
-    case 52:
-      ACCEPT_TOKEN(aux_sym_expansion_token1);
-      END_STATE();
-    case 53:
-      ACCEPT_TOKEN(aux_sym_expansion_token1);
-      if (lookahead == '\n') ADVANCE(61);
-      if (lookahead == '\t' ||
-          lookahead == ' ' ||
-          lookahead == '\\' ||
-          lookahead == 'n') ADVANCE(73);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(34);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(aux_sym_expansion_token1);
-      if (lookahead == '*') ADVANCE(7);
-      if (lookahead == '/') ADVANCE(44);
-      END_STATE();
-    case 55:
-      ACCEPT_TOKEN(aux_sym_expansion_token1);
-      if (lookahead == '-') ADVANCE(71);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(66);
-      END_STATE();
-    case 56:
-      ACCEPT_TOKEN(aux_sym_expansion_token1);
-      if (lookahead == 'd') ADVANCE(15);
-      if (lookahead == 'e') ADVANCE(28);
-      if (lookahead == 'i') ADVANCE(21);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(10);
-      END_STATE();
-    case 57:
-      ACCEPT_TOKEN(aux_sym_expansion_token1);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(71);
-      END_STATE();
-    case 58:
-      ACCEPT_TOKEN(aux_sym_expansion_token2);
-      END_STATE();
-    case 59:
-      ACCEPT_TOKEN(aux_sym_expansion_token2);
-      if (lookahead == '\n') ADVANCE(61);
-      END_STATE();
-    case 60:
-      ACCEPT_TOKEN(aux_sym_expansion_token2);
-      if (lookahead == '*') ADVANCE(7);
-      if (lookahead == '/') ADVANCE(44);
-      END_STATE();
-    case 61:
-      ACCEPT_TOKEN(aux_sym_expansion_token3);
-      END_STATE();
-    case 62:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
-      END_STATE();
-    case 63:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
-      END_STATE();
-    case 64:
-      ACCEPT_TOKEN(aux_sym_ifdef_directive_token3);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(aux_sym_else_directive_token1);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '-') ADVANCE(71);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(66);
-      END_STATE();
-    case 67:
-      ACCEPT_TOKEN(sym_identifier);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(67);
-      END_STATE();
-    case 68:
+    case 51:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 69:
+    case 52:
+      ACCEPT_TOKEN(aux_sym_resource_token1);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(aux_sym_resource_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"') ADVANCE(70);
+      END_STATE();
+    case 54:
       ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
-    case 70:
+    case 55:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 71:
+    case 56:
+      ACCEPT_TOKEN(sym_component);
+      if (lookahead == '-') ADVANCE(57);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(56);
+      END_STATE();
+    case 57:
       ACCEPT_TOKEN(sym_component);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(71);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(57);
       END_STATE();
-    case 72:
+    case 58:
       ACCEPT_TOKEN(sym_any_component);
       END_STATE();
-    case 73:
+    case 59:
       ACCEPT_TOKEN(sym_escape_sequence);
       END_STATE();
-    case 74:
+    case 60:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       END_STATE();
-    case 75:
+    case 61:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
-      if (lookahead == '*') ADVANCE(7);
-      if (lookahead == '/') ADVANCE(44);
+      if (lookahead == '*') ADVANCE(6);
+      if (lookahead == '/') ADVANCE(45);
       END_STATE();
-    case 76:
+    case 62:
+      ACCEPT_TOKEN(aux_sym_resource_value_token1);
+      if (lookahead == 'd') ADVANCE(14);
+      if (lookahead == 'e') ADVANCE(27);
+      if (lookahead == 'i') ADVANCE(20);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(9);
+      END_STATE();
+    case 63:
       ACCEPT_TOKEN(aux_sym_resource_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == ' ' ||
           lookahead == '\\' ||
-          lookahead == 'n') ADVANCE(73);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(34);
+          lookahead == 'n') ADVANCE(59);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(33);
       END_STATE();
-    case 77:
+    case 64:
       ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
-    case 78:
+    case 65:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '\r') ADVANCE(46);
-      if (lookahead == '\\') ADVANCE(42);
+      if (lookahead == '\r') ADVANCE(49);
+      if (lookahead == '\\') ADVANCE(43);
       if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(44);
-      if (lookahead != 0) ADVANCE(43);
+          lookahead == '"') ADVANCE(45);
+      if (lookahead != 0) ADVANCE(44);
       END_STATE();
-    case 79:
+    case 66:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(81);
-      if (lookahead == '/') ADVANCE(43);
+      if (lookahead == '*') ADVANCE(68);
+      if (lookahead == '/') ADVANCE(44);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(83);
+          lookahead != '"') ADVANCE(70);
       END_STATE();
-    case 80:
+    case 67:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(80);
-      if (lookahead == '/') ADVANCE(47);
+      if (lookahead == '*') ADVANCE(67);
+      if (lookahead == '/') ADVANCE(50);
       if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(7);
-      if (lookahead != 0) ADVANCE(81);
+          lookahead == '"') ADVANCE(6);
+      if (lookahead != 0) ADVANCE(68);
       END_STATE();
-    case 81:
+    case 68:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '*') ADVANCE(80);
+      if (lookahead == '*') ADVANCE(67);
       if (lookahead == '\n' ||
-          lookahead == '"') ADVANCE(7);
-      if (lookahead != 0) ADVANCE(81);
+          lookahead == '"') ADVANCE(6);
+      if (lookahead != 0) ADVANCE(68);
       END_STATE();
-    case 82:
+    case 69:
       ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '/') ADVANCE(79);
+      if (lookahead == '/') ADVANCE(66);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(51);
+          lookahead == ' ') ADVANCE(53);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(83);
+          lookahead != '"') ADVANCE(70);
       END_STATE();
-    case 83:
+    case 70:
       ACCEPT_TOKEN(aux_sym_string_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '"') ADVANCE(83);
+          lookahead != '"') ADVANCE(70);
+      END_STATE();
+    case 71:
+      ACCEPT_TOKEN(aux_sym_include_directive_token1);
+      END_STATE();
+    case 72:
+      ACCEPT_TOKEN(aux_sym_define_directive_token1);
+      END_STATE();
+    case 73:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\n') ADVANCE(6);
+      if (lookahead == '*') ADVANCE(73);
+      if (lookahead == '/') ADVANCE(47);
+      if (lookahead == '\\') ADVANCE(77);
+      if (lookahead != 0) ADVANCE(74);
+      END_STATE();
+    case 74:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\n') ADVANCE(6);
+      if (lookahead == '*') ADVANCE(73);
+      if (lookahead == '\\') ADVANCE(77);
+      if (lookahead != 0) ADVANCE(74);
+      END_STATE();
+    case 75:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\r') ADVANCE(40);
+      if (lookahead == '\\') ADVANCE(42);
+      if (lookahead != 0) ADVANCE(48);
+      END_STATE();
+    case 76:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '*') ADVANCE(74);
+      if (lookahead == '/') ADVANCE(48);
+      if (lookahead == '\\') ADVANCE(79);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(78);
+      END_STATE();
+    case 77:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '*') ADVANCE(73);
+      if (lookahead == '\\') ADVANCE(77);
+      if (lookahead != 0) ADVANCE(74);
+      END_STATE();
+    case 78:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\\') ADVANCE(79);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(78);
+      END_STATE();
+    case 79:
+      ACCEPT_TOKEN(sym_expansion);
+      if (lookahead == '\\') ADVANCE(79);
+      if (lookahead != 0) ADVANCE(78);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token1);
+      END_STATE();
+    case 81:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token2);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(aux_sym_ifdef_directive_token3);
+      END_STATE();
+    case 83:
+      ACCEPT_TOKEN(aux_sym_else_directive_token1);
+      END_STATE();
+    case 84:
+      ACCEPT_TOKEN(sym_identifier);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
       END_STATE();
     default:
       return false;
@@ -914,59 +895,56 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 36},
-  [2] = {.lex_state = 36},
-  [3] = {.lex_state = 36},
-  [4] = {.lex_state = 36},
-  [5] = {.lex_state = 36},
-  [6] = {.lex_state = 36},
-  [7] = {.lex_state = 36},
-  [8] = {.lex_state = 36},
-  [9] = {.lex_state = 36},
-  [10] = {.lex_state = 36},
-  [11] = {.lex_state = 36},
-  [12] = {.lex_state = 36},
-  [13] = {.lex_state = 36},
-  [14] = {.lex_state = 2},
-  [15] = {.lex_state = 36},
-  [16] = {.lex_state = 2},
-  [17] = {.lex_state = 36},
-  [18] = {.lex_state = 36},
-  [19] = {.lex_state = 36},
+  [1] = {.lex_state = 35},
+  [2] = {.lex_state = 35},
+  [3] = {.lex_state = 35},
+  [4] = {.lex_state = 35},
+  [5] = {.lex_state = 35},
+  [6] = {.lex_state = 35},
+  [7] = {.lex_state = 35},
+  [8] = {.lex_state = 35},
+  [9] = {.lex_state = 35},
+  [10] = {.lex_state = 35},
+  [11] = {.lex_state = 35},
+  [12] = {.lex_state = 35},
+  [13] = {.lex_state = 1},
+  [14] = {.lex_state = 35},
+  [15] = {.lex_state = 35},
+  [16] = {.lex_state = 1},
+  [17] = {.lex_state = 35},
+  [18] = {.lex_state = 35},
+  [19] = {.lex_state = 35},
   [20] = {.lex_state = 1},
-  [21] = {.lex_state = 3},
-  [22] = {.lex_state = 3},
-  [23] = {.lex_state = 2},
-  [24] = {.lex_state = 1},
-  [25] = {.lex_state = 2},
-  [26] = {.lex_state = 3},
-  [27] = {.lex_state = 36},
-  [28] = {.lex_state = 2},
-  [29] = {.lex_state = 36},
-  [30] = {.lex_state = 36},
-  [31] = {.lex_state = 1},
-  [32] = {.lex_state = 36},
-  [33] = {.lex_state = 0},
-  [34] = {.lex_state = 8},
+  [21] = {.lex_state = 1},
+  [22] = {.lex_state = 35},
+  [23] = {.lex_state = 35},
+  [24] = {.lex_state = 2},
+  [25] = {.lex_state = 35},
+  [26] = {.lex_state = 2},
+  [27] = {.lex_state = 2},
+  [28] = {.lex_state = 1},
+  [29] = {.lex_state = 35},
+  [30] = {.lex_state = 35},
+  [31] = {.lex_state = 0},
+  [32] = {.lex_state = 0},
+  [33] = {.lex_state = 7},
+  [34] = {.lex_state = 0},
   [35] = {.lex_state = 0},
   [36] = {.lex_state = 0},
-  [37] = {.lex_state = 0},
+  [37] = {.lex_state = 69},
   [38] = {.lex_state = 0},
   [39] = {.lex_state = 0},
-  [40] = {.lex_state = 0},
+  [40] = {.lex_state = 35},
   [41] = {.lex_state = 0},
-  [42] = {.lex_state = 36},
-  [43] = {.lex_state = 0},
+  [42] = {.lex_state = 0},
+  [43] = {.lex_state = 7},
   [44] = {.lex_state = 0},
-  [45] = {.lex_state = 8},
-  [46] = {.lex_state = 82},
-  [47] = {.lex_state = 0},
-  [48] = {.lex_state = 0},
+  [45] = {.lex_state = 0},
+  [46] = {.lex_state = 0},
+  [47] = {.lex_state = 35},
+  [48] = {.lex_state = 35},
   [49] = {.lex_state = 0},
-  [50] = {.lex_state = 36},
-  [51] = {.lex_state = 36},
-  [52] = {.lex_state = 0},
-  [53] = {.lex_state = 36},
+  [50] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -975,18 +953,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__line_token1] = ACTIONS(1),
     [sym_comment] = ACTIONS(1),
     [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_include_directive_token1] = ACTIONS(1),
-    [aux_sym_define_directive_token1] = ACTIONS(1),
-    [aux_sym_define_directive_token2] = ACTIONS(3),
-    [aux_sym_expansion_token1] = ACTIONS(1),
-    [aux_sym_expansion_token2] = ACTIONS(1),
-    [aux_sym_expansion_token3] = ACTIONS(1),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(1),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(1),
-    [aux_sym_ifdef_directive_token3] = ACTIONS(1),
-    [aux_sym_else_directive_token1] = ACTIONS(1),
-    [sym_identifier] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
+    [aux_sym_resource_token1] = ACTIONS(3),
     [anon_sym_DOT] = ACTIONS(1),
     [anon_sym_STAR] = ACTIONS(1),
     [sym_component] = ACTIONS(1),
@@ -994,195 +962,202 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_escape_sequence] = ACTIONS(1),
     [aux_sym_resource_value_token1] = ACTIONS(1),
     [anon_sym_DQUOTE] = ACTIONS(1),
+    [aux_sym_include_directive_token1] = ACTIONS(1),
+    [aux_sym_define_directive_token1] = ACTIONS(1),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(1),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(1),
+    [aux_sym_ifdef_directive_token3] = ACTIONS(1),
+    [aux_sym_else_directive_token1] = ACTIONS(1),
+    [sym_identifier] = ACTIONS(1),
   },
   [1] = {
-    [sym_resources] = STATE(43),
+    [sym_resources] = STATE(50),
     [sym__line] = STATE(9),
-    [sym__statement] = STATE(47),
-    [sym_include_directive] = STATE(47),
-    [sym_define_directive] = STATE(47),
-    [sym_ifdef_directive] = STATE(47),
-    [sym_resource] = STATE(47),
-    [sym_components] = STATE(51),
+    [sym__statement] = STATE(44),
+    [sym_resource] = STATE(44),
+    [sym_components] = STATE(48),
     [sym_binding] = STATE(10),
+    [sym_include_directive] = STATE(44),
+    [sym_define_directive] = STATE(44),
+    [sym_ifdef_directive] = STATE(44),
     [aux_sym_resources_repeat1] = STATE(5),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(27),
+    [aux_sym_components_repeat2] = STATE(22),
     [ts_builtin_sym_end] = ACTIONS(5),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_include_directive_token1] = ACTIONS(11),
-    [aux_sym_define_directive_token1] = ACTIONS(13),
-    [aux_sym_define_directive_token2] = ACTIONS(3),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(15),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(15),
-    [anon_sym_DOT] = ACTIONS(17),
-    [anon_sym_STAR] = ACTIONS(17),
-    [sym_component] = ACTIONS(19),
-    [sym_any_component] = ACTIONS(21),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
   },
   [2] = {
     [sym__line] = STATE(9),
-    [sym__statement] = STATE(47),
-    [sym_include_directive] = STATE(47),
-    [sym_define_directive] = STATE(47),
-    [sym_ifdef_directive] = STATE(47),
-    [sym_resource] = STATE(47),
-    [sym_components] = STATE(51),
+    [sym__statement] = STATE(44),
+    [sym_resource] = STATE(44),
+    [sym_components] = STATE(48),
     [sym_binding] = STATE(10),
+    [sym_include_directive] = STATE(44),
+    [sym_define_directive] = STATE(44),
+    [sym_ifdef_directive] = STATE(44),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(27),
+    [aux_sym_components_repeat2] = STATE(22),
     [ts_builtin_sym_end] = ACTIONS(23),
     [aux_sym__line_token1] = ACTIONS(25),
     [sym_comment] = ACTIONS(28),
     [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_include_directive_token1] = ACTIONS(31),
-    [aux_sym_define_directive_token1] = ACTIONS(34),
-    [aux_sym_define_directive_token2] = ACTIONS(3),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(37),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(37),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(31),
+    [anon_sym_STAR] = ACTIONS(31),
+    [sym_component] = ACTIONS(34),
+    [sym_any_component] = ACTIONS(37),
+    [aux_sym_include_directive_token1] = ACTIONS(40),
+    [aux_sym_define_directive_token1] = ACTIONS(43),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(46),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(46),
     [aux_sym_ifdef_directive_token3] = ACTIONS(23),
     [aux_sym_else_directive_token1] = ACTIONS(23),
-    [anon_sym_DOT] = ACTIONS(40),
-    [anon_sym_STAR] = ACTIONS(40),
-    [sym_component] = ACTIONS(43),
-    [sym_any_component] = ACTIONS(46),
   },
   [3] = {
     [sym__line] = STATE(9),
-    [sym__statement] = STATE(47),
-    [sym_include_directive] = STATE(47),
-    [sym_define_directive] = STATE(47),
-    [sym_ifdef_directive] = STATE(47),
-    [sym_else_directive] = STATE(50),
-    [sym_resource] = STATE(47),
-    [sym_components] = STATE(51),
+    [sym__statement] = STATE(44),
+    [sym_resource] = STATE(44),
+    [sym_components] = STATE(48),
     [sym_binding] = STATE(10),
+    [sym_include_directive] = STATE(44),
+    [sym_define_directive] = STATE(44),
+    [sym_ifdef_directive] = STATE(44),
+    [sym_else_directive] = STATE(47),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(27),
+    [aux_sym_components_repeat2] = STATE(22),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_include_directive_token1] = ACTIONS(11),
-    [aux_sym_define_directive_token1] = ACTIONS(13),
-    [aux_sym_define_directive_token2] = ACTIONS(3),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(15),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(15),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
     [aux_sym_ifdef_directive_token3] = ACTIONS(49),
     [aux_sym_else_directive_token1] = ACTIONS(51),
-    [anon_sym_DOT] = ACTIONS(17),
-    [anon_sym_STAR] = ACTIONS(17),
-    [sym_component] = ACTIONS(19),
-    [sym_any_component] = ACTIONS(21),
   },
   [4] = {
     [sym__line] = STATE(9),
-    [sym__statement] = STATE(47),
-    [sym_include_directive] = STATE(47),
-    [sym_define_directive] = STATE(47),
-    [sym_ifdef_directive] = STATE(47),
-    [sym_else_directive] = STATE(42),
-    [sym_resource] = STATE(47),
-    [sym_components] = STATE(51),
+    [sym__statement] = STATE(44),
+    [sym_resource] = STATE(44),
+    [sym_components] = STATE(48),
     [sym_binding] = STATE(10),
+    [sym_include_directive] = STATE(44),
+    [sym_define_directive] = STATE(44),
+    [sym_ifdef_directive] = STATE(44),
+    [sym_else_directive] = STATE(30),
     [aux_sym_resources_repeat1] = STATE(3),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(27),
+    [aux_sym_components_repeat2] = STATE(22),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_include_directive_token1] = ACTIONS(11),
-    [aux_sym_define_directive_token1] = ACTIONS(13),
-    [aux_sym_define_directive_token2] = ACTIONS(3),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(15),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(15),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
     [aux_sym_ifdef_directive_token3] = ACTIONS(53),
     [aux_sym_else_directive_token1] = ACTIONS(51),
-    [anon_sym_DOT] = ACTIONS(17),
-    [anon_sym_STAR] = ACTIONS(17),
-    [sym_component] = ACTIONS(19),
-    [sym_any_component] = ACTIONS(21),
   },
   [5] = {
     [sym__line] = STATE(9),
-    [sym__statement] = STATE(47),
-    [sym_include_directive] = STATE(47),
-    [sym_define_directive] = STATE(47),
-    [sym_ifdef_directive] = STATE(47),
-    [sym_resource] = STATE(47),
-    [sym_components] = STATE(51),
+    [sym__statement] = STATE(44),
+    [sym_resource] = STATE(44),
+    [sym_components] = STATE(48),
     [sym_binding] = STATE(10),
+    [sym_include_directive] = STATE(44),
+    [sym_define_directive] = STATE(44),
+    [sym_ifdef_directive] = STATE(44),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(27),
+    [aux_sym_components_repeat2] = STATE(22),
     [ts_builtin_sym_end] = ACTIONS(55),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_include_directive_token1] = ACTIONS(11),
-    [aux_sym_define_directive_token1] = ACTIONS(13),
-    [aux_sym_define_directive_token2] = ACTIONS(3),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(15),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(15),
-    [anon_sym_DOT] = ACTIONS(17),
-    [anon_sym_STAR] = ACTIONS(17),
-    [sym_component] = ACTIONS(19),
-    [sym_any_component] = ACTIONS(21),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
   },
   [6] = {
     [sym__line] = STATE(9),
-    [sym__statement] = STATE(47),
-    [sym_include_directive] = STATE(47),
-    [sym_define_directive] = STATE(47),
-    [sym_ifdef_directive] = STATE(47),
-    [sym_resource] = STATE(47),
-    [sym_components] = STATE(51),
+    [sym__statement] = STATE(44),
+    [sym_resource] = STATE(44),
+    [sym_components] = STATE(48),
     [sym_binding] = STATE(10),
+    [sym_include_directive] = STATE(44),
+    [sym_define_directive] = STATE(44),
+    [sym_ifdef_directive] = STATE(44),
     [aux_sym_resources_repeat1] = STATE(7),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(27),
+    [aux_sym_components_repeat2] = STATE(22),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_include_directive_token1] = ACTIONS(11),
-    [aux_sym_define_directive_token1] = ACTIONS(13),
-    [aux_sym_define_directive_token2] = ACTIONS(3),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(15),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(15),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
     [aux_sym_ifdef_directive_token3] = ACTIONS(57),
-    [anon_sym_DOT] = ACTIONS(17),
-    [anon_sym_STAR] = ACTIONS(17),
-    [sym_component] = ACTIONS(19),
-    [sym_any_component] = ACTIONS(21),
   },
   [7] = {
     [sym__line] = STATE(9),
-    [sym__statement] = STATE(47),
-    [sym_include_directive] = STATE(47),
-    [sym_define_directive] = STATE(47),
-    [sym_ifdef_directive] = STATE(47),
-    [sym_resource] = STATE(47),
-    [sym_components] = STATE(51),
+    [sym__statement] = STATE(44),
+    [sym_resource] = STATE(44),
+    [sym_components] = STATE(48),
     [sym_binding] = STATE(10),
+    [sym_include_directive] = STATE(44),
+    [sym_define_directive] = STATE(44),
+    [sym_ifdef_directive] = STATE(44),
     [aux_sym_resources_repeat1] = STATE(2),
     [aux_sym_components_repeat1] = STATE(10),
-    [aux_sym_components_repeat2] = STATE(27),
+    [aux_sym_components_repeat2] = STATE(22),
     [aux_sym__line_token1] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
     [sym_preprocessor_comment] = ACTIONS(3),
-    [aux_sym_include_directive_token1] = ACTIONS(11),
-    [aux_sym_define_directive_token1] = ACTIONS(13),
-    [aux_sym_define_directive_token2] = ACTIONS(3),
-    [aux_sym_ifdef_directive_token1] = ACTIONS(15),
-    [aux_sym_ifdef_directive_token2] = ACTIONS(15),
+    [aux_sym_resource_token1] = ACTIONS(3),
+    [anon_sym_DOT] = ACTIONS(11),
+    [anon_sym_STAR] = ACTIONS(11),
+    [sym_component] = ACTIONS(13),
+    [sym_any_component] = ACTIONS(15),
+    [aux_sym_include_directive_token1] = ACTIONS(17),
+    [aux_sym_define_directive_token1] = ACTIONS(19),
+    [aux_sym_ifdef_directive_token1] = ACTIONS(21),
+    [aux_sym_ifdef_directive_token2] = ACTIONS(21),
     [aux_sym_ifdef_directive_token3] = ACTIONS(59),
-    [anon_sym_DOT] = ACTIONS(17),
-    [anon_sym_STAR] = ACTIONS(17),
-    [sym_component] = ACTIONS(19),
-    [sym_any_component] = ACTIONS(21),
   },
 };
 
@@ -1190,50 +1165,50 @@ static const uint16_t ts_small_parse_table[] = {
   [0] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
+      aux_sym_resource_token1,
     ACTIONS(61), 13,
       ts_builtin_sym_end,
       aux_sym__line_token1,
       sym_comment,
+      anon_sym_DOT,
+      anon_sym_STAR,
+      sym_component,
+      sym_any_component,
       aux_sym_include_directive_token1,
       aux_sym_define_directive_token1,
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
       aux_sym_ifdef_directive_token3,
       aux_sym_else_directive_token1,
-      anon_sym_DOT,
-      anon_sym_STAR,
-      sym_component,
-      sym_any_component,
   [20] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
+      aux_sym_resource_token1,
     ACTIONS(63), 13,
       ts_builtin_sym_end,
       aux_sym__line_token1,
       sym_comment,
+      anon_sym_DOT,
+      anon_sym_STAR,
+      sym_component,
+      sym_any_component,
       aux_sym_include_directive_token1,
       aux_sym_define_directive_token1,
       aux_sym_ifdef_directive_token1,
       aux_sym_ifdef_directive_token2,
       aux_sym_ifdef_directive_token3,
       aux_sym_else_directive_token1,
-      anon_sym_DOT,
-      anon_sym_STAR,
-      sym_component,
-      sym_any_component,
   [40] = 6,
-    ACTIONS(21), 1,
+    ACTIONS(15), 1,
       sym_any_component,
     ACTIONS(65), 1,
       sym_component,
-    STATE(29), 1,
+    STATE(25), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-    ACTIONS(17), 2,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
     STATE(11), 2,
@@ -1242,7 +1217,7 @@ static const uint16_t ts_small_parse_table[] = {
   [62] = 4,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
+      aux_sym_resource_token1,
     ACTIONS(67), 2,
       anon_sym_DOT,
       anon_sym_STAR,
@@ -1255,8 +1230,8 @@ static const uint16_t ts_small_parse_table[] = {
   [79] = 4,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-    ACTIONS(17), 2,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
     ACTIONS(72), 2,
@@ -1265,40 +1240,40 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(11), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [96] = 4,
+  [96] = 7,
+    ACTIONS(3), 1,
+      sym_preprocessor_comment,
     ACTIONS(74), 1,
+      aux_sym_resource_token1,
+    ACTIONS(76), 1,
+      sym_escape_sequence,
+    ACTIONS(78), 1,
+      aux_sym_resource_value_token1,
+    STATE(16), 1,
+      aux_sym_resource_repeat1,
+    STATE(20), 1,
+      aux_sym_resource_value_repeat1,
+    STATE(31), 1,
+      sym_resource_value,
+  [118] = 4,
+    ACTIONS(80), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-    ACTIONS(17), 2,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
     STATE(12), 2,
       sym_binding,
       aux_sym_components_repeat1,
-  [112] = 7,
-    ACTIONS(3), 1,
-      sym_preprocessor_comment,
-    ACTIONS(76), 1,
-      aux_sym_define_directive_token2,
-    ACTIONS(78), 1,
-      sym_escape_sequence,
-    ACTIONS(80), 1,
-      aux_sym_resource_value_token1,
-    STATE(16), 1,
-      aux_sym_define_directive_repeat1,
-    STATE(23), 1,
-      aux_sym_resource_value_repeat1,
-    STATE(33), 1,
-      sym_resource_value,
   [134] = 4,
     ACTIONS(82), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-    ACTIONS(17), 2,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
     STATE(12), 2,
@@ -1307,25 +1282,25 @@ static const uint16_t ts_small_parse_table[] = {
   [150] = 7,
     ACTIONS(3), 1,
       sym_preprocessor_comment,
-    ACTIONS(78), 1,
+    ACTIONS(76), 1,
       sym_escape_sequence,
-    ACTIONS(80), 1,
+    ACTIONS(78), 1,
       aux_sym_resource_value_token1,
     ACTIONS(84), 1,
-      aux_sym_define_directive_token2,
-    STATE(23), 1,
+      aux_sym_resource_token1,
+    STATE(20), 1,
       aux_sym_resource_value_repeat1,
     STATE(28), 1,
-      aux_sym_define_directive_repeat1,
-    STATE(44), 1,
+      aux_sym_resource_repeat1,
+    STATE(42), 1,
       sym_resource_value,
   [172] = 4,
     ACTIONS(86), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-    ACTIONS(17), 2,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
     STATE(12), 2,
@@ -1334,8 +1309,8 @@ static const uint16_t ts_small_parse_table[] = {
   [188] = 3,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-    ACTIONS(17), 2,
+      aux_sym_resource_token1,
+    ACTIONS(11), 2,
       anon_sym_DOT,
       anon_sym_STAR,
     STATE(12), 2,
@@ -1344,283 +1319,243 @@ static const uint16_t ts_small_parse_table[] = {
   [201] = 2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
+      aux_sym_resource_token1,
     ACTIONS(88), 4,
       anon_sym_DOT,
       anon_sym_STAR,
       sym_component,
       sym_any_component,
-  [212] = 6,
-    ACTIONS(3), 1,
-      sym_preprocessor_comment,
+  [212] = 5,
     ACTIONS(90), 1,
       aux_sym__line_token1,
     ACTIONS(92), 1,
-      aux_sym_define_directive_token2,
+      sym_escape_sequence,
     ACTIONS(94), 1,
-      aux_sym_expansion_token1,
-    STATE(24), 1,
-      aux_sym_define_directive_repeat1,
-    STATE(37), 1,
-      sym_expansion,
-  [231] = 5,
+      aux_sym_resource_value_token1,
+    STATE(21), 1,
+      aux_sym_resource_value_repeat1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [229] = 5,
     ACTIONS(96), 1,
       aux_sym__line_token1,
     ACTIONS(98), 1,
-      aux_sym_expansion_token2,
-    ACTIONS(100), 1,
-      aux_sym_expansion_token3,
-    STATE(22), 1,
-      aux_sym_expansion_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [248] = 5,
-    ACTIONS(102), 1,
-      aux_sym__line_token1,
-    ACTIONS(104), 1,
-      aux_sym_expansion_token2,
-    ACTIONS(106), 1,
-      aux_sym_expansion_token3,
-    STATE(26), 1,
-      aux_sym_expansion_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [265] = 5,
-    ACTIONS(108), 1,
-      aux_sym__line_token1,
-    ACTIONS(110), 1,
       sym_escape_sequence,
-    ACTIONS(112), 1,
+    ACTIONS(101), 1,
       aux_sym_resource_value_token1,
-    STATE(25), 1,
+    STATE(21), 1,
       aux_sym_resource_value_repeat1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [282] = 6,
-    ACTIONS(3), 1,
-      sym_preprocessor_comment,
-    ACTIONS(94), 1,
-      aux_sym_expansion_token1,
-    ACTIONS(114), 1,
-      aux_sym__line_token1,
-    ACTIONS(116), 1,
-      aux_sym_define_directive_token2,
-    STATE(31), 1,
-      aux_sym_define_directive_repeat1,
-    STATE(38), 1,
-      sym_expansion,
-  [301] = 5,
-    ACTIONS(118), 1,
-      aux_sym__line_token1,
-    ACTIONS(120), 1,
-      sym_escape_sequence,
-    ACTIONS(123), 1,
-      aux_sym_resource_value_token1,
-    STATE(25), 1,
-      aux_sym_resource_value_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [318] = 5,
-    ACTIONS(126), 1,
-      aux_sym__line_token1,
-    ACTIONS(128), 1,
-      aux_sym_expansion_token2,
-    ACTIONS(131), 1,
-      aux_sym_expansion_token3,
-    STATE(26), 1,
-      aux_sym_expansion_repeat1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [335] = 4,
-    ACTIONS(21), 1,
+      aux_sym_resource_token1,
+  [246] = 4,
+    ACTIONS(15), 1,
       sym_any_component,
     ACTIONS(65), 1,
       sym_component,
-    STATE(30), 1,
+    STATE(23), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [349] = 5,
-    ACTIONS(3), 1,
-      sym_preprocessor_comment,
-    ACTIONS(134), 1,
-      aux_sym_define_directive_token2,
-    ACTIONS(137), 1,
-      sym_escape_sequence,
-    ACTIONS(139), 1,
-      aux_sym_resource_value_token1,
-    STATE(28), 1,
-      aux_sym_define_directive_repeat1,
-  [365] = 4,
-    ACTIONS(21), 1,
-      sym_any_component,
-    ACTIONS(141), 1,
-      sym_component,
-    STATE(30), 1,
+      aux_sym_resource_token1,
+  [260] = 3,
+    STATE(23), 1,
       aux_sym_components_repeat2,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [379] = 3,
-    STATE(30), 1,
-      aux_sym_components_repeat2,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-    ACTIONS(143), 2,
+      aux_sym_resource_token1,
+    ACTIONS(104), 2,
       sym_component,
       sym_any_component,
-  [391] = 5,
-    ACTIONS(3), 1,
-      sym_preprocessor_comment,
-    ACTIONS(137), 1,
+  [272] = 5,
+    ACTIONS(107), 1,
       aux_sym__line_token1,
-    ACTIONS(139), 1,
-      aux_sym_expansion_token1,
-    ACTIONS(146), 1,
-      aux_sym_define_directive_token2,
-    STATE(31), 1,
-      aux_sym_define_directive_repeat1,
-  [407] = 3,
-    ACTIONS(149), 1,
+    ACTIONS(109), 1,
+      sym_preprocessor_comment,
+    ACTIONS(111), 1,
+      aux_sym_resource_token1,
+    ACTIONS(113), 1,
+      sym_expansion,
+    STATE(26), 1,
+      aux_sym_resource_repeat1,
+  [288] = 4,
+    ACTIONS(15), 1,
+      sym_any_component,
+    ACTIONS(115), 1,
+      sym_component,
+    STATE(23), 1,
+      aux_sym_components_repeat2,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [302] = 5,
+    ACTIONS(109), 1,
+      sym_preprocessor_comment,
+    ACTIONS(117), 1,
+      aux_sym__line_token1,
+    ACTIONS(119), 1,
+      aux_sym_resource_token1,
+    ACTIONS(121), 1,
+      sym_expansion,
+    STATE(27), 1,
+      aux_sym_resource_repeat1,
+  [318] = 5,
+    ACTIONS(109), 1,
+      sym_preprocessor_comment,
+    ACTIONS(123), 1,
+      aux_sym__line_token1,
+    ACTIONS(125), 1,
+      aux_sym_resource_token1,
+    ACTIONS(128), 1,
+      sym_expansion,
+    STATE(27), 1,
+      aux_sym_resource_repeat1,
+  [334] = 5,
+    ACTIONS(3), 1,
+      sym_preprocessor_comment,
+    ACTIONS(123), 1,
+      sym_escape_sequence,
+    ACTIONS(128), 1,
+      aux_sym_resource_value_token1,
+    ACTIONS(130), 1,
+      aux_sym_resource_token1,
+    STATE(28), 1,
+      aux_sym_resource_repeat1,
+  [350] = 3,
+    ACTIONS(133), 1,
       anon_sym_DQUOTE,
-    STATE(39), 1,
+    STATE(34), 1,
       sym_string,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [418] = 2,
+      aux_sym_resource_token1,
+  [361] = 2,
+    ACTIONS(135), 1,
+      aux_sym_ifdef_directive_token3,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [369] = 2,
+    ACTIONS(137), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [377] = 2,
+    ACTIONS(139), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [385] = 2,
+    ACTIONS(141), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [393] = 2,
+    ACTIONS(143), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [401] = 2,
+    ACTIONS(145), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [409] = 2,
+    ACTIONS(147), 1,
+      aux_sym__line_token1,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [417] = 2,
+    ACTIONS(149), 1,
+      aux_sym_string_token1,
+    ACTIONS(109), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [425] = 2,
     ACTIONS(151), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [426] = 2,
+      aux_sym_resource_token1,
+  [433] = 2,
     ACTIONS(153), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [434] = 2,
-    ACTIONS(155), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [442] = 2,
+      aux_sym_resource_token1,
+  [441] = 2,
+    ACTIONS(155), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(3), 2,
+      sym_preprocessor_comment,
+      aux_sym_resource_token1,
+  [449] = 2,
     ACTIONS(157), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [450] = 2,
+      aux_sym_resource_token1,
+  [457] = 2,
     ACTIONS(159), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [458] = 2,
+      aux_sym_resource_token1,
+  [465] = 2,
     ACTIONS(161), 1,
-      aux_sym__line_token1,
+      sym_identifier,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [466] = 2,
+      aux_sym_resource_token1,
+  [473] = 2,
     ACTIONS(163), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [474] = 2,
+      aux_sym_resource_token1,
+  [481] = 2,
     ACTIONS(165), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [482] = 2,
+      aux_sym_resource_token1,
+  [489] = 2,
     ACTIONS(167), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [490] = 2,
+      aux_sym_resource_token1,
+  [497] = 2,
     ACTIONS(169), 1,
       aux_sym_ifdef_directive_token3,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [498] = 2,
+      aux_sym_resource_token1,
+  [505] = 2,
     ACTIONS(171), 1,
-      ts_builtin_sym_end,
+      anon_sym_COLON,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [506] = 2,
+      aux_sym_resource_token1,
+  [513] = 2,
     ACTIONS(173), 1,
       aux_sym__line_token1,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [514] = 2,
+      aux_sym_resource_token1,
+  [521] = 2,
     ACTIONS(175), 1,
-      sym_identifier,
+      ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [522] = 2,
-    ACTIONS(179), 1,
-      aux_sym_string_token1,
-    ACTIONS(177), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [530] = 2,
-    ACTIONS(181), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [538] = 2,
-    ACTIONS(183), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [546] = 2,
-    ACTIONS(185), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [554] = 2,
-    ACTIONS(187), 1,
-      aux_sym_ifdef_directive_token3,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [562] = 2,
-    ACTIONS(189), 1,
-      anon_sym_COLON,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [570] = 2,
-    ACTIONS(191), 1,
-      aux_sym__line_token1,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
-  [578] = 2,
-    ACTIONS(193), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(3), 2,
-      sym_preprocessor_comment,
-      aux_sym_define_directive_token2,
+      aux_sym_resource_token1,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
@@ -1630,46 +1565,43 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(11)] = 62,
   [SMALL_STATE(12)] = 79,
   [SMALL_STATE(13)] = 96,
-  [SMALL_STATE(14)] = 112,
+  [SMALL_STATE(14)] = 118,
   [SMALL_STATE(15)] = 134,
   [SMALL_STATE(16)] = 150,
   [SMALL_STATE(17)] = 172,
   [SMALL_STATE(18)] = 188,
   [SMALL_STATE(19)] = 201,
   [SMALL_STATE(20)] = 212,
-  [SMALL_STATE(21)] = 231,
-  [SMALL_STATE(22)] = 248,
-  [SMALL_STATE(23)] = 265,
-  [SMALL_STATE(24)] = 282,
-  [SMALL_STATE(25)] = 301,
-  [SMALL_STATE(26)] = 318,
-  [SMALL_STATE(27)] = 335,
-  [SMALL_STATE(28)] = 349,
-  [SMALL_STATE(29)] = 365,
-  [SMALL_STATE(30)] = 379,
-  [SMALL_STATE(31)] = 391,
-  [SMALL_STATE(32)] = 407,
-  [SMALL_STATE(33)] = 418,
-  [SMALL_STATE(34)] = 426,
-  [SMALL_STATE(35)] = 434,
-  [SMALL_STATE(36)] = 442,
-  [SMALL_STATE(37)] = 450,
-  [SMALL_STATE(38)] = 458,
-  [SMALL_STATE(39)] = 466,
-  [SMALL_STATE(40)] = 474,
-  [SMALL_STATE(41)] = 482,
-  [SMALL_STATE(42)] = 490,
-  [SMALL_STATE(43)] = 498,
-  [SMALL_STATE(44)] = 506,
-  [SMALL_STATE(45)] = 514,
-  [SMALL_STATE(46)] = 522,
-  [SMALL_STATE(47)] = 530,
-  [SMALL_STATE(48)] = 538,
-  [SMALL_STATE(49)] = 546,
-  [SMALL_STATE(50)] = 554,
-  [SMALL_STATE(51)] = 562,
-  [SMALL_STATE(52)] = 570,
-  [SMALL_STATE(53)] = 578,
+  [SMALL_STATE(21)] = 229,
+  [SMALL_STATE(22)] = 246,
+  [SMALL_STATE(23)] = 260,
+  [SMALL_STATE(24)] = 272,
+  [SMALL_STATE(25)] = 288,
+  [SMALL_STATE(26)] = 302,
+  [SMALL_STATE(27)] = 318,
+  [SMALL_STATE(28)] = 334,
+  [SMALL_STATE(29)] = 350,
+  [SMALL_STATE(30)] = 361,
+  [SMALL_STATE(31)] = 369,
+  [SMALL_STATE(32)] = 377,
+  [SMALL_STATE(33)] = 385,
+  [SMALL_STATE(34)] = 393,
+  [SMALL_STATE(35)] = 401,
+  [SMALL_STATE(36)] = 409,
+  [SMALL_STATE(37)] = 417,
+  [SMALL_STATE(38)] = 425,
+  [SMALL_STATE(39)] = 433,
+  [SMALL_STATE(40)] = 441,
+  [SMALL_STATE(41)] = 449,
+  [SMALL_STATE(42)] = 457,
+  [SMALL_STATE(43)] = 465,
+  [SMALL_STATE(44)] = 473,
+  [SMALL_STATE(45)] = 481,
+  [SMALL_STATE(46)] = 489,
+  [SMALL_STATE(47)] = 497,
+  [SMALL_STATE(48)] = 505,
+  [SMALL_STATE(49)] = 513,
+  [SMALL_STATE(50)] = 521,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -1678,91 +1610,83 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 0, 0, 0),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
   [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0),
   [25] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(9),
-  [28] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(47),
-  [31] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
-  [34] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(45),
-  [37] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(34),
-  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
-  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(15),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
-  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [28] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(44),
+  [31] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
+  [34] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
+  [37] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(18),
+  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(29),
+  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(43),
+  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
+  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
   [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resources, 1, 0, 0),
   [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 2, 0, 0),
   [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_directive, 3, 0, 0),
   [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__line, 2, 0, 0),
   [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resources_repeat1, 1, 0, 0),
-  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
   [67] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
   [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat1, 2, 0, 0),
   [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0),
-  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
-  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [78] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [80] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
+  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [78] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 2, 0, 0),
+  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
   [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 3, 0, 0),
+  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_components, 1, 0, 0),
   [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binding, 1, 0, 0),
-  [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
-  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
+  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
   [94] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expansion, 1, 0, 0),
-  [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expansion, 2, 0, 0),
-  [104] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [106] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource_value, 1, 0, 0),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [112] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 2),
-  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
-  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
-  [123] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
-  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_expansion_repeat1, 2, 0, 0),
-  [128] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_expansion_repeat1, 2, 0, 0), SHIFT_REPEAT(26),
-  [131] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_expansion_repeat1, 2, 0, 0), SHIFT_REPEAT(26),
-  [134] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_define_directive_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
-  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_define_directive_repeat1, 2, 0, 0),
-  [139] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_define_directive_repeat1, 2, 0, 0),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [143] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(18),
-  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_define_directive_repeat1, 2, 0, 0), SHIFT_REPEAT(31),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 4),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
-  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
-  [161] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 4, 0, 5),
-  [163] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
-  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 6),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [171] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 7),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [177] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [179] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
-  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [183] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 8),
-  [185] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 9),
-  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 10),
-  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0),
+  [98] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
+  [101] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_resource_value_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
+  [104] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_components_repeat2, 2, 0, 0), SHIFT_REPEAT(18),
+  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 2, 0, 2),
+  [109] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [111] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [113] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 2),
+  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [121] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
+  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [125] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(27),
+  [128] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0),
+  [130] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_resource_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
+  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 3, 0, 4),
+  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include_directive, 2, 0, 1),
+  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
+  [147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 4, 0, 5),
+  [149] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 4, 0, 6),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_define_directive, 3, 0, 3),
+  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_resource, 4, 0, 7),
+  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 8),
+  [167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 5, 0, 9),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ifdef_directive, 6, 0, 10),
+  [175] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -344,6 +344,25 @@ Hello.world: 100
         value: (expansion)))))
 
 ==================================================
+Simple directive
+==================================================
+#warning "Hello"
+#unsupported This is a simple macro
+#empty
+
+--------------------------------------------------
+
+(resources
+  (simple_directive
+    name: (directive)
+    value: (expansion))
+  (simple_directive
+    name: (directive)
+    value: (expansion))
+  (simple_directive
+    name: (directive)))
+
+==================================================
 Directive with whitespace
 ==================================================
 # define hello world

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -264,10 +264,14 @@ Hello.world: 100
 
 #  endif
 
-#ifdef VAR
-#define color #346
+#ifdef VAR_1
+  #define color #346
+#elifdef VAR_2
+  #define color #784
+#elifndef VAR_3
+  #define color #F59
 #else
-#define color #389
+  #define color #389
 #endif
 
 --------------------------------------------------
@@ -288,6 +292,16 @@ Hello.world: 100
   (ifdef_directive
     condition: (identifier)
     consequence: (body
+      (define_directive
+        name: (identifier)
+        value: (expansion)))
+    alternative: (elifdef_directive
+      condition: (identifier)
+      (define_directive
+        name: (identifier)
+        value: (expansion)))
+    alternative: (elifdef_directive
+      condition: (identifier)
       (define_directive
         name: (identifier)
         value: (expansion)))

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -194,6 +194,20 @@ octal: \033[31m
     value: (expansion)))
 
 ==================================================
+#undef directive
+==================================================
+#undef SOME_CONSTANT
+#undef COLOR4
+
+--------------------------------------------------
+
+(resources
+  (undef_directive
+    name: (identifier))
+  (undef_directive
+    name: (identifier)))
+
+==================================================
 #ifdef directive
 ==================================================
 #ifdef SOME_MACRO_DEFINED

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -254,7 +254,40 @@ octal: \033[31m
     name: (identifier)))
 
 ==================================================
-#ifdef directive
+#if and #elif directive
+==================================================
+#if 0
+  *background: #43
+#elif 10
+  // No resouce
+#else
+  #ifdef color
+    // nested
+  #endif
+#endif
+
+--------------------------------------------------
+
+(resources
+  (if_directive
+    condition: (expansion)
+    consequence: (body
+      (resource
+        name: (components
+          (binding)
+          (component))
+        value: (resource_value)))
+    alternative: (elif_directive
+      condition: (expansion)
+      (preprocessor_comment))
+    alternative: (else_directive
+      (ifdef_directive
+        condition: (identifier)
+        (preprocessor_comment)
+        consequence: (body)))))
+
+==================================================
+#ifdef, #ifndef, #elifdef and #elifndef directive
 ==================================================
 #ifdef SOME_MACRO_DEFINED
 Hello.world: 100

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -178,10 +178,12 @@ octal: \033[31m
       (string_content))))
 
 ==================================================
-#define directive
+#define directive (constant)
 ==================================================
 #define SOME_CONSTANT 78
 #define COLOR4 #5665F2
+#define EMPTY
+#define EMPTY_SPACE   
 
 --------------------------------------------------
 
@@ -191,6 +193,50 @@ octal: \033[31m
     value: (expansion))
   (define_directive
     name: (identifier)
+    value: (expansion))
+  (define_directive
+    name: (identifier))
+  (define_directive
+    name: (identifier)))
+
+==================================================
+#define directive (function)
+==================================================
+#define empty()   
+#define hello1()  Hello
+#define hello2(one)
+#define hello3(one, two) ((one) + (two))
+#define hello4(X, ...)  Hello __VA_ARGS__, I am X
+#define hello5(...) Hello __VA_ARGS__
+
+--------------------------------------------------
+
+(resources
+  (define_function_directive
+    name: (identifier)
+    parameters: (parameters))
+  (define_function_directive
+    name: (identifier)
+    parameters: (parameters)
+    value: (expansion))
+  (define_function_directive
+    name: (identifier)
+    parameters: (parameters
+      (identifier)))
+  (define_function_directive
+    name: (identifier)
+    parameters: (parameters
+      (identifier)
+      (identifier))
+    value: (expansion))
+  (define_function_directive
+    name: (identifier)
+    parameters: (parameters
+      (identifier))
+    value: (expansion))
+  (define_function_directive
+    name: (identifier)
+    parameters: (parameters)
     value: (expansion)))
 
 ==================================================


### PR DESCRIPTION
Right now only a limited set of preprocessor directives are supported, the ones that I've commonly seen used and are used for testing in this repository. However, I've found examples in other repositories using more directives than the ones defined here, so it might be better to implement them.

Directives:

- [x] Function macros
- [x] `#undef`
- [x] `#if`
- [x] `#elif`
- [x] `#elifdef`
- [x] `#elifndef`